### PR TITLE
[Feature] ToC 스크롤바 스타일 개선

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -1,0 +1,30 @@
+@import "tailwindcss";
+
+@layer utilities {
+  .custom-scrollbar::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  .custom-scrollbar::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  .custom-scrollbar::-webkit-scrollbar-thumb {
+    background-color: var(--color-gray-300);
+    border-radius: 9999px;
+  }
+
+  .dark .custom-scrollbar::-webkit-scrollbar-thumb {
+    background-color: var(--color-gray-600);
+  }
+
+  /* Firefox 지원 */
+  .custom-scrollbar {
+    scrollbar-width: thin;
+    scrollbar-color: var(--color-gray-300) transparent;
+  }
+
+  .dark .custom-scrollbar {
+    scrollbar-color: var(--color-gray-600) transparent;
+  }
+}

--- a/apps/web/src/components/post/TableOfContents.tsx
+++ b/apps/web/src/components/post/TableOfContents.tsx
@@ -51,7 +51,7 @@ export function TableOfContents({ content }: TableOfContentsProps) {
       {
         rootMargin: '-80px 0px -80% 0px',
         threshold: 0,
-      }
+      },
     );
 
     const headingElements = document.querySelectorAll('h1[id], h2[id], h3[id]');
@@ -81,11 +81,9 @@ export function TableOfContents({ content }: TableOfContentsProps) {
   }
 
   return (
-    <nav className="hidden xl:block sticky top-24 w-64 max-h-[calc(100vh-8rem)] overflow-y-auto [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-gray-300 dark:[&::-webkit-scrollbar-thumb]:bg-gray-600">
-      <div className="border-l-2 border-gray-200 dark:border-gray-700 pl-4">
-        <h4 className="text-sm font-semibold text-gray-900 dark:text-white mb-4">
-          목차
-        </h4>
+    <nav className="sticky top-24 hidden max-h-[calc(100vh-30rem)] w-64 overflow-y-auto xl:block custom-scrollbar">
+      <div className="border-l-2 border-gray-200 pl-4 dark:border-gray-700">
+        <h4 className="mb-4 text-sm font-semibold text-gray-900 dark:text-white">목차</h4>
         <ul className="space-y-2">
           {headings.map((heading, index) => (
             <li
@@ -94,7 +92,7 @@ export function TableOfContents({ content }: TableOfContentsProps) {
             >
               <button
                 onClick={() => handleClick(heading.id)}
-                className={`cursor-pointer text-left text-sm leading-relaxed transition-colors duration-200 hover:text-primary-500 ${
+                className={`hover:text-primary-500 cursor-pointer text-left text-sm leading-relaxed transition-colors duration-200 ${
                   activeId === heading.id
                     ? 'text-primary-500 font-medium'
                     : 'text-gray-500 dark:text-gray-400'

--- a/apps/web/src/components/post/TableOfContents.tsx
+++ b/apps/web/src/components/post/TableOfContents.tsx
@@ -81,7 +81,7 @@ export function TableOfContents({ content }: TableOfContentsProps) {
   }
 
   return (
-    <nav className="hidden xl:block sticky top-24 w-64 max-h-[calc(100vh-8rem)] overflow-y-auto">
+    <nav className="hidden xl:block sticky top-24 w-64 max-h-[calc(100vh-8rem)] overflow-y-auto [&::-webkit-scrollbar]:w-1.5 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:rounded-full [&::-webkit-scrollbar-thumb]:bg-gray-300 dark:[&::-webkit-scrollbar-thumb]:bg-gray-600">
       <div className="border-l-2 border-gray-200 dark:border-gray-700 pl-4">
         <h4 className="text-sm font-semibold text-gray-900 dark:text-white mb-4">
           목차


### PR DESCRIPTION
## Summary
- ToC(목차) 컴포넌트에 스크롤바 스타일링 추가
- 스크롤바 너비, 둥근 모서리, 다크모드 색상 지원

## Changes
- `[&::-webkit-scrollbar]:w-1.5` - 스크롤바 너비 6px
- `[&::-webkit-scrollbar-thumb]:rounded-full` - 둥근 스크롤바
- 다크모드: `gray-300` → `gray-600`

## Test plan
- [x] 긴 목차가 있는 블로그 포스트에서 스크롤 확인
- [x] 다크모드에서 스크롤바 색상 확인

Closes #41

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * 테이블 목차의 레이아웃과 반응형 동작이 개선되어 넓은 화면에서 고정(sticky) 위치에 더 큰 영역(최대 높이 확대)을 사용합니다.
  * 테이블 목차의 스크롤바 디자인이 개선되어 라이트/다크 모드에서 일관된 시각 효과를 제공합니다. 기능적 변화는 없습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->