### PR TITLE
[Refactor] AdminGuard 관리자 판별 로직 단순화

### DIFF
--- a/apps/api/src/auth/guards/admin.guard.ts
+++ b/apps/api/src/auth/guards/admin.guard.ts
@@ -16,8 +16,8 @@ export class AdminGuard implements CanActivate {
       throw new ForbiddenException('User not authenticated');
     }
 
-    // 표준: user_metadata.role === 'admin' 확인
-    const isAdmin = user.user_metadata?.role === 'admin';
+    // 표준: user_metadata.role === 'admin' 확인 (대소문자 무시)
+    const isAdmin = user.user_metadata?.role?.toLowerCase() === 'admin';
 
     if (!isAdmin) {
       throw new ForbiddenException('Admin access required');

--- a/apps/api/src/auth/guards/admin.guard.ts
+++ b/apps/api/src/auth/guards/admin.guard.ts
@@ -11,25 +11,13 @@ export class AdminGuard implements CanActivate {
   canActivate(context: ExecutionContext): boolean {
     const request = context.switchToHttp().getRequest();
     const user = request.user as AuthUser | undefined;
-    
+
     if (!user) {
       throw new ForbiddenException('User not authenticated');
     }
 
-    // is_admin 플래그 또는 role 확인 (대소문자 구분 없음)
-    const isAdminFlag =
-      user.is_admin === true ||
-      user.is_admin === 'true' ||
-      user.is_admin === '1' ||
-      user.user_metadata?.is_admin === true ||
-      user.user_metadata?.is_admin === 'true' ||
-      user.user_metadata?.is_admin === '1';
-
-    const isAdminRole =
-      user.role?.toLowerCase() === 'admin' ||
-      user.user_metadata?.role?.toLowerCase() === 'admin';
-
-    const isAdmin = isAdminFlag || isAdminRole;
+    // 표준: user_metadata.role === 'admin' 확인
+    const isAdmin = user.user_metadata?.role === 'admin';
 
     if (!isAdmin) {
       throw new ForbiddenException('Admin access required');


### PR DESCRIPTION
## Summary
- 관리자 판별 로직을 `user_metadata.role === 'admin'` 단일 조건으로 단순화
- 기존 복잡한 is_admin 플래그 및 복합 조건 제거

## Changes
- `is_admin` 플래그 (boolean, string '1', 'true') 조건 제거
- `user_metadata.role === 'admin'`만 확인하도록 변경

## Test plan
- [ ] 관리자 계정으로 어드민 페이지 접근 확인
- [ ] 일반 사용자 계정으로 어드민 페이지 접근 차단 확인

Closes #36

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 관리자 권한 판정을 여러 플래그/메타데이터 검사에서 단일 역할 기반 확인으로 간소화했습니다.
  * 인증 흐름(인증 후 권한 확인)은 유지되며, 인증되지 않거나 관리자 권한이 없을 경우 접근이 차단됩니다.

<sub>✏️ Tip: 검토 설정에서 이 요약을 맞춤화할 수 있습니다.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->