### PR TITLE
[Feature] #37 Post-User Prisma 관계 명시적 정의

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -19,6 +19,7 @@ model User {
   role      Role     @default(USER)
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
+  posts     Post[]
 
   @@map("users")
 }
@@ -36,7 +37,8 @@ model Resume {
 // Post model - for blog
 model Post {
   id         Int      @id @default(autoincrement())
-  authorId   String   @map("author_id") // Supabase Auth user ID
+  authorId   String   @map("author_id")
+  author     User     @relation(fields: [authorId], references: [id], onDelete: Cascade)
   title      String
   slug       String   @unique
   content    String   // Markdown content

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -6,9 +6,17 @@ import { ResumeModule } from './resume';
 import { AuthModule } from './auth';
 import { PostsModule } from './posts';
 import { TagsModule } from './tags';
+import { UsersModule } from './users';
 
 @Module({
-  imports: [PrismaModule, ResumeModule, AuthModule, PostsModule, TagsModule],
+  imports: [
+    PrismaModule,
+    ResumeModule,
+    AuthModule,
+    PostsModule,
+    TagsModule,
+    UsersModule,
+  ],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/apps/api/src/users/dto/index.ts
+++ b/apps/api/src/users/dto/index.ts
@@ -1,0 +1,1 @@
+export { SyncUsersDto } from './sync-users.dto';

--- a/apps/api/src/users/dto/sync-users.dto.ts
+++ b/apps/api/src/users/dto/sync-users.dto.ts
@@ -1,0 +1,32 @@
+import { IsArray, IsString, IsOptional, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+
+class UserMetadataDto {
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  role?: string;
+}
+
+class SupabaseUserDto {
+  @IsString()
+  id: string;
+
+  @IsString()
+  email: string;
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => UserMetadataDto)
+  user_metadata?: UserMetadataDto;
+}
+
+export class SyncUsersDto {
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => SupabaseUserDto)
+  users: SupabaseUserDto[];
+}

--- a/apps/api/src/users/index.ts
+++ b/apps/api/src/users/index.ts
@@ -1,0 +1,4 @@
+export { UsersModule } from './users.module';
+export { UsersService } from './users.service';
+export { UsersController } from './users.controller';
+export * from './dto';

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -1,0 +1,43 @@
+import { Controller, Get, Post, Body, UseGuards, Logger } from '@nestjs/common';
+import { UsersService } from './users.service';
+import { SupabaseGuard } from '../auth/guards/supabase.guard';
+import { AdminGuard } from '../auth/guards/admin.guard';
+import { SyncUsersDto } from './dto';
+
+@Controller('users')
+export class UsersController {
+  private readonly logger = new Logger(UsersController.name);
+
+  constructor(private readonly usersService: UsersService) {}
+
+  /**
+   * POST /users/sync
+   * Supabase Auth 사용자를 로컬 DB에 동기화 (Admin 전용)
+   */
+  @Post('sync')
+  @UseGuards(SupabaseGuard, AdminGuard)
+  async syncUsers(@Body() syncUsersDto: SyncUsersDto) {
+    this.logger.log(`Syncing ${syncUsersDto.users.length} users from Supabase`);
+    return this.usersService.syncSupabaseUsers(syncUsersDto.users);
+  }
+
+  /**
+   * GET /users/validate-authors
+   * Post의 authorId 유효성 검사 (Admin 전용)
+   */
+  @Get('validate-authors')
+  @UseGuards(SupabaseGuard, AdminGuard)
+  async validateAuthors() {
+    return this.usersService.validatePostAuthors();
+  }
+
+  /**
+   * GET /users
+   * 모든 사용자 목록 조회 (Admin 전용)
+   */
+  @Get()
+  @UseGuards(SupabaseGuard, AdminGuard)
+  async findAll() {
+    return this.usersService.findAll();
+  }
+}

--- a/apps/api/src/users/users.module.ts
+++ b/apps/api/src/users/users.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { UsersController } from './users.controller';
+import { UsersService } from './users.service';
+
+@Module({
+  controllers: [UsersController],
+  providers: [UsersService],
+  exports: [UsersService],
+})
+export class UsersModule {}

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -39,6 +39,10 @@ export class UsersService {
           data: {
             email: supabaseUser.email,
             name: supabaseUser.user_metadata?.name ?? existingUser.name,
+            role:
+              supabaseUser.user_metadata?.role?.toUpperCase() === 'ADMIN'
+                ? 'ADMIN'
+                : 'USER',
           },
         });
         updated++;
@@ -87,6 +91,10 @@ export class UsersService {
       update: {
         email: supabaseUser.email,
         name: supabaseUser.user_metadata?.name,
+        role:
+          supabaseUser.user_metadata?.role?.toUpperCase() === 'ADMIN'
+            ? 'ADMIN'
+            : 'USER',
       },
     });
   }

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -137,7 +137,6 @@ export class UsersService {
   async findById(id: string) {
     return this.prisma.user.findUnique({
       where: { id },
-      include: { posts: true },
     });
   }
 

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -103,22 +103,23 @@ export class UsersService {
       select: { id: true, authorId: true },
     });
 
-    const invalidAuthorIds: string[] = [];
+    const postAuthorIds = new Set(posts.map((post) => post.authorId));
 
-    for (const post of posts) {
-      const user = await this.prisma.user.findUnique({
-        where: { id: post.authorId },
-      });
+    const existingUsers = await this.prisma.user.findMany({
+      where: { id: { in: Array.from(postAuthorIds) } },
+      select: { id: true },
+    });
 
-      if (!user) {
-        invalidAuthorIds.push(post.authorId);
-      }
-    }
+    const existingUserIds = new Set(existingUsers.map((user) => user.id));
+
+    const invalidAuthorIds = Array.from(postAuthorIds).filter(
+      (id) => !existingUserIds.has(id),
+    );
 
     return {
       total: posts.length,
       valid: posts.length - invalidAuthorIds.length,
-      invalid: [...new Set(invalidAuthorIds)],
+      invalid: invalidAuthorIds,
     };
   }
 

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -1,0 +1,143 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+
+interface SupabaseUser {
+  id: string;
+  email: string;
+  user_metadata?: {
+    name?: string;
+    role?: string;
+  };
+}
+
+@Injectable()
+export class UsersService {
+  private readonly logger = new Logger(UsersService.name);
+
+  constructor(private readonly prisma: PrismaService) {}
+
+  /**
+   * Supabase Auth 사용자를 로컬 User 테이블에 동기화 (upsert)
+   * 마이그레이션 전 또는 사용자 로그인 시 호출
+   */
+  async syncSupabaseUsers(supabaseUsers: SupabaseUser[]): Promise<{
+    synced: number;
+    created: number;
+    updated: number;
+  }> {
+    let created = 0;
+    let updated = 0;
+
+    for (const supabaseUser of supabaseUsers) {
+      const existingUser = await this.prisma.user.findUnique({
+        where: { id: supabaseUser.id },
+      });
+
+      if (existingUser) {
+        await this.prisma.user.update({
+          where: { id: supabaseUser.id },
+          data: {
+            email: supabaseUser.email,
+            name: supabaseUser.user_metadata?.name ?? existingUser.name,
+          },
+        });
+        updated++;
+      } else {
+        await this.prisma.user.create({
+          data: {
+            id: supabaseUser.id,
+            email: supabaseUser.email,
+            name: supabaseUser.user_metadata?.name,
+            role:
+              supabaseUser.user_metadata?.role?.toUpperCase() === 'ADMIN'
+                ? 'ADMIN'
+                : 'USER',
+          },
+        });
+        created++;
+      }
+    }
+
+    this.logger.log(
+      `Synced ${supabaseUsers.length} users: ${created} created, ${updated} updated`,
+    );
+
+    return {
+      synced: supabaseUsers.length,
+      created,
+      updated,
+    };
+  }
+
+  /**
+   * 단일 사용자 동기화 (로그인 시 사용)
+   */
+  async syncUser(supabaseUser: SupabaseUser) {
+    return this.prisma.user.upsert({
+      where: { id: supabaseUser.id },
+      create: {
+        id: supabaseUser.id,
+        email: supabaseUser.email,
+        name: supabaseUser.user_metadata?.name,
+        role:
+          supabaseUser.user_metadata?.role?.toUpperCase() === 'ADMIN'
+            ? 'ADMIN'
+            : 'USER',
+      },
+      update: {
+        email: supabaseUser.email,
+        name: supabaseUser.user_metadata?.name,
+      },
+    });
+  }
+
+  /**
+   * Post의 authorId가 유효한 User를 참조하는지 검증
+   */
+  async validatePostAuthors(): Promise<{
+    total: number;
+    valid: number;
+    invalid: string[];
+  }> {
+    const posts = await this.prisma.post.findMany({
+      select: { id: true, authorId: true },
+    });
+
+    const invalidAuthorIds: string[] = [];
+
+    for (const post of posts) {
+      const user = await this.prisma.user.findUnique({
+        where: { id: post.authorId },
+      });
+
+      if (!user) {
+        invalidAuthorIds.push(post.authorId);
+      }
+    }
+
+    return {
+      total: posts.length,
+      valid: posts.length - invalidAuthorIds.length,
+      invalid: [...new Set(invalidAuthorIds)],
+    };
+  }
+
+  /**
+   * ID로 사용자 조회
+   */
+  async findById(id: string) {
+    return this.prisma.user.findUnique({
+      where: { id },
+      include: { posts: true },
+    });
+  }
+
+  /**
+   * 모든 사용자 조회
+   */
+  async findAll() {
+    return this.prisma.user.findMany({
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+}

--- a/docs/database.md
+++ b/docs/database.md
@@ -18,14 +18,16 @@
 │ role (ENUM)     │
 │ createdAt       │
 │ updatedAt       │
-└─────────────────┘
-
-┌─────────────────┐         ┌─────────────────┐
-│      Post       │         │      Tag        │
-├─────────────────┤         ├─────────────────┤
-│ id (PK)         │◄──n:m──►│ id (PK)         │
-│ authorId        │         │ name (UNIQUE)   │
-│ title           │         └─────────────────┘
+│ posts[]         │──────┐
+└─────────────────┘      │
+                         │ 1:N
+┌─────────────────┐      │    ┌─────────────────┐
+│      Post       │◄─────┘    │      Tag        │
+├─────────────────┤           ├─────────────────┤
+│ id (PK)         │◄───n:m───►│ id (PK)         │
+│ authorId (FK)   │           │ name (UNIQUE)   │
+│ author          │           └─────────────────┘
+│ title           │
 │ slug (UNIQUE)   │
 │ content         │
 │ excerpt         │
@@ -60,6 +62,7 @@ model User {
   role      Role     @default(USER)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+  posts     Post[]
 }
 
 enum Role {
@@ -74,6 +77,7 @@ enum Role {
 | email | String | 로그인 이메일 (고유) |
 | name | String? | 표시 이름 |
 | role | Role | USER 또는 ADMIN |
+| posts | Post[] | 작성한 포스트 목록 (1:N) |
 
 ### Post
 
@@ -83,6 +87,7 @@ enum Role {
 model Post {
   id         Int      @id @default(autoincrement())
   authorId   String
+  author     User     @relation(fields: [authorId], references: [id], onDelete: Cascade)
   title      String
   slug       String   @unique
   content    String
@@ -103,7 +108,8 @@ model Post {
 | 필드 | 타입 | 설명 |
 |------|------|------|
 | id | Int | Auto-increment PK |
-| authorId | String | Supabase Auth 사용자 ID (User와 논리적 관계) |
+| authorId | String | User ID (외래 키) |
+| author | User | 작성자 (1:N 관계) |
 | title | String | 포스트 제목 |
 | slug | String | URL 친화적 식별자 (자동 생성) |
 | content | String | 마크다운 본문 |
@@ -204,6 +210,35 @@ interface ResumeContent {
 ```
 
 ## 관계
+
+### User ↔ Post (일대다)
+
+```prisma
+// User
+posts Post[]
+
+// Post
+authorId String
+author   User @relation(fields: [authorId], references: [id], onDelete: Cascade)
+```
+
+User 삭제 시 연관된 Post도 함께 삭제됨 (`onDelete: Cascade`)
+
+#### 조회 예시
+
+```typescript
+// 사용자와 작성한 포스트 함께 조회
+const userWithPosts = await prisma.user.findUnique({
+  where: { id: userId },
+  include: { posts: true }
+});
+
+// 포스트와 작성자 함께 조회
+const postWithAuthor = await prisma.post.findUnique({
+  where: { id: postId },
+  include: { author: true }
+});
+```
 
 ### Post ↔ Tag (다대다)
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -355,6 +355,60 @@ model Post {
 }
 ```
 
+### Post-User FK 적용 시 데이터 동기화
+
+Post.authorId에 User 참조 FK를 적용하기 전에 Supabase Auth 사용자를 로컬 User 테이블에 동기화해야 합니다.
+
+#### 1. 사용자 동기화 API 호출
+
+```bash
+# Supabase Admin API에서 사용자 목록 가져오기
+curl -X GET "https://<project>.supabase.co/auth/v1/admin/users" \
+  -H "Authorization: Bearer <service_role_key>" \
+  -H "apikey: <service_role_key>"
+```
+
+#### 2. 로컬 DB에 동기화
+
+```bash
+# POST /users/sync (Admin 권한 필요)
+curl -X POST "http://localhost:3001/users/sync" \
+  -H "Authorization: Bearer <admin_token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "users": [
+      {
+        "id": "supabase-user-id",
+        "email": "user@example.com",
+        "user_metadata": { "name": "User Name", "role": "admin" }
+      }
+    ]
+  }'
+```
+
+#### 3. authorId 유효성 검사
+
+```bash
+# GET /users/validate-authors (Admin 권한 필요)
+curl -X GET "http://localhost:3001/users/validate-authors" \
+  -H "Authorization: Bearer <admin_token>"
+
+# 응답 예시
+{
+  "total": 10,
+  "valid": 8,
+  "invalid": ["missing-user-id-1", "missing-user-id-2"]
+}
+```
+
+#### 4. 마이그레이션 순서
+
+1. `pnpm db:generate` - Prisma 클라이언트 생성
+2. Supabase Auth 사용자를 `/users/sync` API로 동기화
+3. `/users/validate-authors`로 무효한 authorId 확인
+4. 무효한 데이터 수정 (Prisma Studio 또는 스크립트)
+5. `pnpm db:push` - FK 제약조건 적용
+
 ## 성능 최적화
 
 ### 인덱스 전략

--- a/docs/database.md
+++ b/docs/database.md
@@ -218,7 +218,7 @@ interface ResumeContent {
 posts Post[]
 
 // Post
-authorId String
+authorId String @map("author_id")
 author   User @relation(fields: [authorId], references: [id], onDelete: Cascade)
 ```
 


### PR DESCRIPTION
## 변경 사항

- Post 모델에 `author` 관계 필드 추가 (`@relation`)
- User 모델에 `posts` 역관계 추가
- `onDelete: Cascade`로 사용자 삭제 시 연관 포스트 자동 삭제

## 변경된 파일

- `apps/api/prisma/schema.prisma` (+4, -1)
- `docs/database.md` (+45, -8)

## 관련 이슈

- Closes #37

## 테스트

- [ ] 로컬에서 테스트 완료
- [ ] 빌드 성공 확인

## 체크리스트

- [ ] 코드 리뷰 완료
- [ ] 타입 체크 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **데이터베이스**
  * 사용자(User)와 포스트(Post) 간 1:N 관계를 추가하고, 사용자 삭제 시 연관 포스트가 자동으로 삭제되도록 설정했습니다.

* **신규 기능**
  * 사용자 관리 API 추가: POST /users/sync(대량 동기화), GET /users/validate-authors(작성자 검증), GET /users(사용자 조회).
  * 대량 동기화 입력 검증 DTO를 도입해 입력 유효성 검사 및 구조화된 동기화를 지원합니다.

* **문서**
  * 관계 설명, 예시 쿼리, 동기화 및 마이그레이션 가이드를 보강했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->