### PR TITLE
[Fix] #60 admin 권한 체크를 user_metadata에서 app_metadata로 변경

### DIFF
--- a/apps/api/src/auth/decorators/current-user.decorator.ts
+++ b/apps/api/src/auth/decorators/current-user.decorator.ts
@@ -8,10 +8,12 @@ export interface AuthUser {
   id: string;
   email: string;
   role: string;
-  is_admin?: boolean | string;
-  user_metadata?: {
-    is_admin?: boolean | string;
+  app_metadata?: {
     role?: string;
+    [key: string]: unknown;
+  };
+  user_metadata?: {
+    name?: string;
     [key: string]: unknown;
   };
 }

--- a/apps/api/src/auth/guards/admin.guard.ts
+++ b/apps/api/src/auth/guards/admin.guard.ts
@@ -16,8 +16,7 @@ export class AdminGuard implements CanActivate {
       throw new ForbiddenException('User not authenticated');
     }
 
-    // 표준: user_metadata.role === 'admin' 확인 (대소문자 무시)
-    const isAdmin = user.user_metadata?.role?.toLowerCase() === 'admin';
+    const isAdmin = user.app_metadata?.role?.toLowerCase() === 'admin';
 
     if (!isAdmin) {
       throw new ForbiddenException('Admin access required');

--- a/apps/api/src/auth/strategies/supabase.strategy.ts
+++ b/apps/api/src/auth/strategies/supabase.strategy.ts
@@ -9,9 +9,12 @@ interface JwtPayload {
   role: string;
   aud: string;
   exp: number;
-  user_metadata?: {
+  app_metadata?: {
     role?: string;
-    is_admin?: boolean;
+    [key: string]: unknown;
+  };
+  user_metadata?: {
+    name?: string;
     [key: string]: unknown;
   };
 }
@@ -47,6 +50,7 @@ export class SupabaseStrategy extends PassportStrategy(Strategy, 'supabase') {
       id: payload.sub,
       email: payload.email,
       role: payload.role,
+      app_metadata: payload.app_metadata,
       user_metadata: payload.user_metadata,
     };
   }

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -13,9 +13,11 @@ import { Role } from '@prisma/client';
 interface SupabaseUser {
   id: string;
   email: string;
+  app_metadata?: {
+    role?: string;
+  };
   user_metadata?: {
     name?: string;
-    role?: string;
   };
 }
 
@@ -65,7 +67,7 @@ export class UsersService {
           data: {
             email: supabaseUser.email,
             name: supabaseUser.user_metadata?.name ?? existingUser.name,
-            role: supabaseUser.user_metadata?.role?.toUpperCase() === 'ADMIN' ? 'ADMIN' : 'USER',
+            role: supabaseUser.app_metadata?.role?.toUpperCase() === 'ADMIN' ? 'ADMIN' : 'USER',
           },
         });
         updated++;
@@ -75,7 +77,7 @@ export class UsersService {
             id: supabaseUser.id,
             email: supabaseUser.email,
             name: supabaseUser.user_metadata?.name,
-            role: supabaseUser.user_metadata?.role?.toUpperCase() === 'ADMIN' ? 'ADMIN' : 'USER',
+            role: supabaseUser.app_metadata?.role?.toUpperCase() === 'ADMIN' ? 'ADMIN' : 'USER',
           },
         });
         created++;
@@ -101,12 +103,12 @@ export class UsersService {
         id: supabaseUser.id,
         email: supabaseUser.email,
         name: supabaseUser.user_metadata?.name,
-        role: supabaseUser.user_metadata?.role?.toUpperCase() === 'ADMIN' ? 'ADMIN' : 'USER',
+        role: supabaseUser.app_metadata?.role?.toUpperCase() === 'ADMIN' ? 'ADMIN' : 'USER',
       },
       update: {
         email: supabaseUser.email,
         name: supabaseUser.user_metadata?.name,
-        role: supabaseUser.user_metadata?.role?.toUpperCase() === 'ADMIN' ? 'ADMIN' : 'USER',
+        role: supabaseUser.app_metadata?.role?.toUpperCase() === 'ADMIN' ? 'ADMIN' : 'USER',
       },
     });
   }
@@ -200,7 +202,7 @@ export class UsersService {
           id: user.id,
           email: user.email,
           name: user.user_metadata?.name || null,
-          role: user.user_metadata?.role?.toUpperCase() === 'ADMIN' ? 'ADMIN' : 'USER',
+          role: user.app_metadata?.role?.toUpperCase() === 'ADMIN' ? 'ADMIN' : 'USER',
           emailConfirmedAt: user.email_confirmed_at ?? null,
           lastSignInAt: user.last_sign_in_at ?? null,
           createdAt: user.created_at,
@@ -282,7 +284,7 @@ export class UsersService {
 
     try {
       const { data, error } = await this.supabaseAdmin.auth.admin.updateUserById(id, {
-        user_metadata: { role: role.toLowerCase() },
+        app_metadata: { role: role.toLowerCase() },
       });
 
       if (error) {
@@ -329,7 +331,7 @@ export class UsersService {
       }
 
       const admins = data.users.filter(
-        (user) => user.user_metadata?.role?.toUpperCase() === 'ADMIN',
+        (user) => user.app_metadata?.role?.toUpperCase() === 'ADMIN',
       );
       return admins.length <= 1 && admins.some((admin) => admin.id === id);
     } catch (err) {

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -26,6 +26,10 @@ export class UsersService {
   private readonly logger = new Logger(UsersService.name);
   private readonly supabaseAdmin: SupabaseClient | null = null;
 
+  private resolveRole(appMetadata?: { role?: string }): Role {
+    return appMetadata?.role?.toUpperCase() === 'ADMIN' ? Role.ADMIN : Role.USER;
+  }
+
   constructor(
     private readonly prisma: PrismaService,
     private readonly configService: ConfigService,
@@ -67,7 +71,7 @@ export class UsersService {
           data: {
             email: supabaseUser.email,
             name: supabaseUser.user_metadata?.name ?? existingUser.name,
-            role: supabaseUser.app_metadata?.role?.toUpperCase() === 'ADMIN' ? 'ADMIN' : 'USER',
+            role: this.resolveRole(supabaseUser.app_metadata),
           },
         });
         updated++;
@@ -77,7 +81,7 @@ export class UsersService {
             id: supabaseUser.id,
             email: supabaseUser.email,
             name: supabaseUser.user_metadata?.name,
-            role: supabaseUser.app_metadata?.role?.toUpperCase() === 'ADMIN' ? 'ADMIN' : 'USER',
+            role: this.resolveRole(supabaseUser.app_metadata),
           },
         });
         created++;
@@ -103,12 +107,12 @@ export class UsersService {
         id: supabaseUser.id,
         email: supabaseUser.email,
         name: supabaseUser.user_metadata?.name,
-        role: supabaseUser.app_metadata?.role?.toUpperCase() === 'ADMIN' ? 'ADMIN' : 'USER',
+        role: this.resolveRole(supabaseUser.app_metadata),
       },
       update: {
         email: supabaseUser.email,
         name: supabaseUser.user_metadata?.name,
-        role: supabaseUser.app_metadata?.role?.toUpperCase() === 'ADMIN' ? 'ADMIN' : 'USER',
+        role: this.resolveRole(supabaseUser.app_metadata),
       },
     });
   }
@@ -202,7 +206,7 @@ export class UsersService {
           id: user.id,
           email: user.email,
           name: user.user_metadata?.name || null,
-          role: user.app_metadata?.role?.toUpperCase() === 'ADMIN' ? 'ADMIN' : 'USER',
+          role: this.resolveRole(user.app_metadata as { role?: string }),
           emailConfirmedAt: user.email_confirmed_at ?? null,
           lastSignInAt: user.last_sign_in_at ?? null,
           createdAt: user.created_at,
@@ -324,16 +328,29 @@ export class UsersService {
     }
 
     try {
-      const { data, error } = await this.supabaseAdmin.auth.admin.listUsers();
-      if (error) {
-        this.logger.error('Failed to list users for last admin check', error);
-        return true; // fail-closed: 에러 시 차단
+      const allAdminIds: string[] = [];
+      const perPage = 100;
+      let page = 1;
+      let hasMore = true;
+
+      while (hasMore) {
+        const { data, error } = await this.supabaseAdmin.auth.admin.listUsers({ page, perPage });
+        if (error) {
+          this.logger.error('Failed to list users for last admin check', error);
+          return true; // fail-closed: 에러 시 차단
+        }
+
+        for (const user of data.users) {
+          if (this.resolveRole(user.app_metadata as { role?: string }) === Role.ADMIN) {
+            allAdminIds.push(user.id);
+          }
+        }
+
+        hasMore = data.users.length >= perPage;
+        page++;
       }
 
-      const admins = data.users.filter(
-        (user) => user.app_metadata?.role?.toUpperCase() === 'ADMIN',
-      );
-      return admins.length <= 1 && admins.some((admin) => admin.id === id);
+      return allAdminIds.length <= 1 && allAdminIds.includes(id);
     } catch (err) {
       this.logger.error('Unexpected error in checkLastAdmin', err);
       return true; // fail-closed: 예외 시 차단

--- a/apps/web/src/app/auth/reset-password/page.tsx
+++ b/apps/web/src/app/auth/reset-password/page.tsx
@@ -2,6 +2,8 @@ import { redirect } from 'next/navigation';
 import { createClient } from '@/lib/supabase/server';
 import { ResetPasswordForm } from './ResetPasswordForm';
 
+export const dynamic = 'force-dynamic';
+
 export default async function ResetPasswordPage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();

--- a/apps/web/src/components/post/PostActions.tsx
+++ b/apps/web/src/components/post/PostActions.tsx
@@ -26,13 +26,9 @@ export function PostActions({ postId, postTitle }: PostActionsProps) {
       } = await supabase.auth.getUser();
 
       if (user) {
-        const isAdminFlag =
-          user.user_metadata?.is_admin === true ||
-          user.user_metadata?.is_admin === 'true' ||
-          user.user_metadata?.is_admin === '1';
         const isAdminRole =
-          (user.user_metadata?.role || '').toLowerCase() === 'admin';
-        setIsAuthenticated(isAdminFlag || isAdminRole);
+          (user.app_metadata?.role || '').toLowerCase() === 'admin';
+        setIsAuthenticated(isAdminRole);
       }
     };
 

--- a/apps/web/src/components/post/PostActions.tsx
+++ b/apps/web/src/components/post/PostActions.tsx
@@ -12,7 +12,7 @@ interface PostActionsProps {
 
 export function PostActions({ postId, postTitle }: PostActionsProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [isAdmin, setIsAdmin] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
@@ -28,7 +28,7 @@ export function PostActions({ postId, postTitle }: PostActionsProps) {
       if (user) {
         const isAdminRole =
           (user.app_metadata?.role || '').toLowerCase() === 'admin';
-        setIsAuthenticated(isAdminRole);
+        setIsAdmin(isAdminRole);
       }
     };
 
@@ -74,7 +74,7 @@ export function PostActions({ postId, postTitle }: PostActionsProps) {
     }
   };
 
-  if (!isAuthenticated) {
+  if (!isAdmin) {
     return null;
   }
 

--- a/apps/web/src/lib/supabase/middleware.ts
+++ b/apps/web/src/lib/supabase/middleware.ts
@@ -1,8 +1,8 @@
 import { createServerClient } from '@supabase/ssr';
 import { NextResponse, type NextRequest } from 'next/server';
 
-function isAdmin(user: { app_metadata: { role?: string } } | null): boolean {
-  return user?.app_metadata?.role?.toLowerCase() === 'admin';
+function isAdmin(user: { app_metadata: Record<string, unknown> } | null): boolean {
+  return (user?.app_metadata?.role as string)?.toLowerCase() === 'admin';
 }
 
 export async function updateSession(request: NextRequest) {

--- a/apps/web/src/lib/supabase/middleware.ts
+++ b/apps/web/src/lib/supabase/middleware.ts
@@ -1,8 +1,8 @@
 import { createServerClient } from '@supabase/ssr';
 import { NextResponse, type NextRequest } from 'next/server';
 
-function isAdmin(user: { app_metadata: Record<string, unknown> } | null): boolean {
-  return user?.app_metadata?.role === 'admin';
+function isAdmin(user: { app_metadata: { role?: string } } | null): boolean {
+  return user?.app_metadata?.role?.toLowerCase() === 'admin';
 }
 
 export async function updateSession(request: NextRequest) {

--- a/apps/web/src/lib/supabase/middleware.ts
+++ b/apps/web/src/lib/supabase/middleware.ts
@@ -1,8 +1,8 @@
 import { createServerClient } from '@supabase/ssr';
 import { NextResponse, type NextRequest } from 'next/server';
 
-function isAdmin(user: { user_metadata?: { role?: string } } | null): boolean {
-  return user?.user_metadata?.role === 'admin';
+function isAdmin(user: { app_metadata: Record<string, unknown> } | null): boolean {
+  return user?.app_metadata?.role === 'admin';
 }
 
 export async function updateSession(request: NextRequest) {


### PR DESCRIPTION
## 변경 사항

- admin 권한 체크 기준을 `user_metadata`에서 `app_metadata`로 전환
- `user_metadata`는 클라이언트에서 변조 가능하여 권한 상승 공격에 취약
- `app_metadata`는 서버 사이드(service_role)에서만 수정 가능

## 변경된 파일

- `apps/api/src/auth/strategies/supabase.strategy.ts` (+8, -2)
- `apps/api/src/auth/decorators/current-user.decorator.ts` (+8, -3)
- `apps/api/src/auth/guards/admin.guard.ts` (+3, -2)
- `apps/api/src/users/users.service.ts` (+18, -8)
- `apps/web/src/components/post/PostActions.tsx` (+8, -6)
- `apps/web/src/lib/supabase/middleware.ts` (+4, -2)

## 관련 이슈

- Closes #60

## 테스트

- [ ] 로컬에서 테스트 완료
- [ ] 빌드 성공 확인

## 체크리스트

- [ ] 코드 리뷰 완료
- [ ] 타입 체크 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 관리자 권한 처리를 통합하여 역할 판정이 일관되게 동작하도록 개선했습니다.
  * 관리자 전용 UI 표시 및 접근 제어가 일관된 역할 기준으로 동작합니다.
  * 사용자 동기화 및 관리 흐름의 오류 처리와 안전성이 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->