### PR TITLE
[Feature] #64 방문자 통계 대시보드 구현

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -75,6 +75,21 @@ model Tag {
   @@map("tags")
 }
 
+// DailyStats model - for visitor statistics
+model DailyStats {
+  id        String   @id @default(uuid())
+  date      DateTime @db.Date
+  postId    Int?     @map("post_id")
+  page      String   // 'blog', 'resume', 'portfolio', or post slug
+  views     Int      @default(0)
+  createdAt DateTime @default(now()) @map("created_at")
+
+  @@unique([date, page])
+  @@index([date])
+  @@index([postId])
+  @@map("daily_stats")
+}
+
 // Role enum
 enum Role {
   USER

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -9,6 +9,7 @@ import { AuthModule } from './auth';
 import { PostsModule } from './posts';
 import { TagsModule } from './tags';
 import { UsersModule } from './users';
+import { StatsModule } from './stats';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { UsersModule } from './users';
     PostsModule,
     TagsModule,
     UsersModule,
+    StatsModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/api/src/posts/posts.module.ts
+++ b/apps/api/src/posts/posts.module.ts
@@ -1,8 +1,10 @@
 import { Module } from '@nestjs/common';
 import { PostsController } from './posts.controller';
 import { PostsService } from './posts.service';
+import { StatsModule } from '../stats';
 
 @Module({
+  imports: [StatsModule],
   controllers: [PostsController],
   providers: [PostsService],
   exports: [PostsService],

--- a/apps/api/src/posts/posts.service.ts
+++ b/apps/api/src/posts/posts.service.ts
@@ -8,12 +8,16 @@ import {
 import { PrismaService } from '../prisma/prisma.service';
 import { CreatePostDto, UpdatePostDto } from './dto';
 import { generateUniqueSlug } from '../common/utils/slug.util';
+import { StatsService } from '../stats/stats.service';
 
 @Injectable()
 export class PostsService implements OnModuleInit {
   private readonly logger = new Logger(PostsService.name);
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly statsService: StatsService,
+  ) {}
 
   async onModuleInit() {
     await this.fixEmptySlugs();
@@ -189,6 +193,10 @@ export class PostsService implements OnModuleInit {
     if (!post) {
       throw new NotFoundException('Post not found');
     }
+
+    this.statsService.recordView(slug, post.id).catch((err) => {
+      this.logger.error(`Failed to record view stat: ${err.message}`);
+    });
 
     return this.prisma.post.update({
       where: { slug },

--- a/apps/api/src/stats/dto/index.ts
+++ b/apps/api/src/stats/dto/index.ts
@@ -1,0 +1,18 @@
+import { IsOptional, IsInt, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class GetDailyStatsQuery {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  days: number = 30;
+}
+
+export class GetTopPostsQuery {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  limit: number = 10;
+}

--- a/apps/api/src/stats/index.ts
+++ b/apps/api/src/stats/index.ts
@@ -1,0 +1,2 @@
+export { StatsModule } from './stats.module';
+export { StatsService } from './stats.service';

--- a/apps/api/src/stats/index.ts
+++ b/apps/api/src/stats/index.ts
@@ -1,2 +1,3 @@
 export { StatsModule } from './stats.module';
 export { StatsService } from './stats.service';
+export { GetDailyStatsQuery, GetTopPostsQuery } from './dto';

--- a/apps/api/src/stats/stats.controller.ts
+++ b/apps/api/src/stats/stats.controller.ts
@@ -1,7 +1,8 @@
-import { Controller, Get, Query, UseGuards, DefaultValuePipe, ParseIntPipe } from '@nestjs/common';
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
 import { StatsService } from './stats.service';
 import { SupabaseGuard } from '../auth/guards/supabase.guard';
 import { AdminGuard } from '../auth/guards/admin.guard';
+import { GetDailyStatsQuery, GetTopPostsQuery } from './dto';
 
 @Controller('stats')
 export class StatsController {
@@ -15,14 +16,14 @@ export class StatsController {
 
   @Get('daily')
   @UseGuards(SupabaseGuard, AdminGuard)
-  async getDailyStats(@Query('days', new DefaultValuePipe(30), ParseIntPipe) days: number) {
-    return this.statsService.getDailyStats(days);
+  async getDailyStats(@Query() query: GetDailyStatsQuery) {
+    return this.statsService.getDailyStats(query.days);
   }
 
   @Get('top-posts')
   @UseGuards(SupabaseGuard, AdminGuard)
-  async getTopPosts(@Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number) {
-    return this.statsService.getTopPosts(limit);
+  async getTopPosts(@Query() query: GetTopPostsQuery) {
+    return this.statsService.getTopPosts(query.limit);
   }
 
   @Get('tags')

--- a/apps/api/src/stats/stats.controller.ts
+++ b/apps/api/src/stats/stats.controller.ts
@@ -1,0 +1,33 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { StatsService } from './stats.service';
+import { SupabaseGuard } from '../auth/guards/supabase.guard';
+import { AdminGuard } from '../auth/guards/admin.guard';
+
+@Controller('stats')
+export class StatsController {
+  constructor(private readonly statsService: StatsService) {}
+
+  @Get('overview')
+  @UseGuards(SupabaseGuard, AdminGuard)
+  async getOverview() {
+    return this.statsService.getOverview();
+  }
+
+  @Get('daily')
+  @UseGuards(SupabaseGuard, AdminGuard)
+  async getDailyStats(@Query('days') days?: string) {
+    return this.statsService.getDailyStats(days ? parseInt(days, 10) : 30);
+  }
+
+  @Get('top-posts')
+  @UseGuards(SupabaseGuard, AdminGuard)
+  async getTopPosts(@Query('limit') limit?: string) {
+    return this.statsService.getTopPosts(limit ? parseInt(limit, 10) : 10);
+  }
+
+  @Get('tags')
+  @UseGuards(SupabaseGuard, AdminGuard)
+  async getTagStats() {
+    return this.statsService.getTagStats();
+  }
+}

--- a/apps/api/src/stats/stats.controller.ts
+++ b/apps/api/src/stats/stats.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { Controller, Get, Query, UseGuards, DefaultValuePipe, ParseIntPipe } from '@nestjs/common';
 import { StatsService } from './stats.service';
 import { SupabaseGuard } from '../auth/guards/supabase.guard';
 import { AdminGuard } from '../auth/guards/admin.guard';
@@ -15,14 +15,14 @@ export class StatsController {
 
   @Get('daily')
   @UseGuards(SupabaseGuard, AdminGuard)
-  async getDailyStats(@Query('days') days?: string) {
-    return this.statsService.getDailyStats(days ? parseInt(days, 10) : 30);
+  async getDailyStats(@Query('days', new DefaultValuePipe(30), ParseIntPipe) days: number) {
+    return this.statsService.getDailyStats(days);
   }
 
   @Get('top-posts')
   @UseGuards(SupabaseGuard, AdminGuard)
-  async getTopPosts(@Query('limit') limit?: string) {
-    return this.statsService.getTopPosts(limit ? parseInt(limit, 10) : 10);
+  async getTopPosts(@Query('limit', new DefaultValuePipe(10), ParseIntPipe) limit: number) {
+    return this.statsService.getTopPosts(limit);
   }
 
   @Get('tags')

--- a/apps/api/src/stats/stats.module.ts
+++ b/apps/api/src/stats/stats.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { StatsController } from './stats.controller';
+import { StatsService } from './stats.service';
+
+@Module({
+  controllers: [StatsController],
+  providers: [StatsService],
+  exports: [StatsService],
+})
+export class StatsModule {}

--- a/apps/api/src/stats/stats.service.ts
+++ b/apps/api/src/stats/stats.service.ts
@@ -21,8 +21,10 @@ export class StatsService {
     startDate.setDate(startDate.getDate() - days);
     startDate.setHours(0, 0, 0, 0);
 
-    const stats = await this.prisma.dailyStats.findMany({
+    const stats = await this.prisma.dailyStats.groupBy({
+      by: ['date'],
       where: { date: { gte: startDate } },
+      _sum: { views: true },
       orderBy: { date: 'asc' },
     });
 
@@ -35,7 +37,7 @@ export class StatsService {
 
     for (const stat of stats) {
       const key = new Date(stat.date).toISOString().split('T')[0];
-      dailyMap.set(key, (dailyMap.get(key) || 0) + stat.views);
+      dailyMap.set(key, stat._sum.views || 0);
     }
 
     return Array.from(dailyMap.entries()).map(([date, views]) => ({ date, views }));
@@ -59,7 +61,7 @@ export class StatsService {
   async getTagStats() {
     const tags = await this.prisma.tag.findMany({
       include: {
-        _count: { select: { posts: true } },
+        _count: { select: { posts: { where: { published: true } } } },
         posts: {
           where: { published: true },
           select: { viewCount: true },

--- a/apps/api/src/stats/stats.service.ts
+++ b/apps/api/src/stats/stats.service.ts
@@ -1,0 +1,107 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Injectable()
+export class StatsService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async recordView(page: string, postId?: number) {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    await this.prisma.dailyStats.upsert({
+      where: { date_page: { date: today, page } },
+      update: { views: { increment: 1 } },
+      create: { date: today, page, postId, views: 1 },
+    });
+  }
+
+  async getDailyStats(days: number = 30) {
+    const startDate = new Date();
+    startDate.setDate(startDate.getDate() - days);
+    startDate.setHours(0, 0, 0, 0);
+
+    const stats = await this.prisma.dailyStats.findMany({
+      where: { date: { gte: startDate } },
+      orderBy: { date: 'asc' },
+    });
+
+    const dailyMap = new Map<string, number>();
+    for (let i = 0; i <= days; i++) {
+      const d = new Date(startDate);
+      d.setDate(d.getDate() + i);
+      dailyMap.set(d.toISOString().split('T')[0], 0);
+    }
+
+    for (const stat of stats) {
+      const key = new Date(stat.date).toISOString().split('T')[0];
+      dailyMap.set(key, (dailyMap.get(key) || 0) + stat.views);
+    }
+
+    return Array.from(dailyMap.entries()).map(([date, views]) => ({ date, views }));
+  }
+
+  async getTopPosts(limit: number = 10) {
+    return this.prisma.post.findMany({
+      where: { published: true },
+      orderBy: { viewCount: 'desc' },
+      take: limit,
+      select: {
+        id: true,
+        title: true,
+        slug: true,
+        viewCount: true,
+        createdAt: true,
+      },
+    });
+  }
+
+  async getTagStats() {
+    const tags = await this.prisma.tag.findMany({
+      include: {
+        _count: { select: { posts: true } },
+        posts: {
+          where: { published: true },
+          select: { viewCount: true },
+        },
+      },
+    });
+
+    return tags
+      .map((tag) => ({
+        name: tag.name,
+        postCount: tag._count.posts,
+        totalViews: tag.posts.reduce((sum, p) => sum + p.viewCount, 0),
+      }))
+      .sort((a, b) => b.totalViews - a.totalViews);
+  }
+
+  async getOverview() {
+    const [totalPosts, publishedPosts, totalViews, todayViews] = await Promise.all([
+      this.prisma.post.count(),
+      this.prisma.post.count({ where: { published: true } }),
+      this.prisma.post.aggregate({ _sum: { viewCount: true } }),
+      this.getTodayViews(),
+    ]);
+
+    return {
+      totalPosts,
+      publishedPosts,
+      draftPosts: totalPosts - publishedPosts,
+      totalViews: totalViews._sum.viewCount || 0,
+      todayViews,
+    };
+  }
+
+  private async getTodayViews() {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    const result = await this.prisma.dailyStats.aggregate({
+      where: { date: today },
+      _sum: { views: true },
+    });
+
+    return result._sum.views || 0;
+  }
+}

--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
-import { FileText, Briefcase, Tags, Settings, PenSquare, ExternalLink, Users, ImageIcon } from 'lucide-react';
+import { FileText, Briefcase, Tags, Settings, PenSquare, ExternalLink, Users, ImageIcon, BarChart3 } from 'lucide-react';
 import { createClient } from '@/lib/supabase/server';
 import { LogoutButton } from '@/components/auth/LogoutButton';
 import { DashboardStats } from '@/components/admin/DashboardStats';
@@ -56,6 +56,14 @@ const menuItems = [
     icon: ImageIcon,
     color: 'text-pink-500',
     bgColor: 'bg-pink-100 dark:bg-pink-900/30',
+  },
+  {
+    href: '/admin/stats',
+    title: '방문자 통계',
+    description: '일별 조회수, 인기 글, 태그별 통계를 확인합니다.',
+    icon: BarChart3,
+    color: 'text-teal-500',
+    bgColor: 'bg-teal-100 dark:bg-teal-900/30',
   },
   {
     href: '/admin/settings',

--- a/apps/web/src/app/admin/stats/page.tsx
+++ b/apps/web/src/app/admin/stats/page.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import Link from 'next/link';
+import { ArrowLeft, Eye, FileText, TrendingUp, Calendar } from 'lucide-react';
+import { api } from '@/lib/api';
+import { createClient } from '@/lib/supabase/client';
+import type { DailyStat, TopPost, TagStat, StatsOverview } from '@/lib/api/stats';
+
+export default function AdminStatsPage() {
+  const [overview, setOverview] = useState<StatsOverview | null>(null);
+  const [dailyStats, setDailyStats] = useState<DailyStat[]>([]);
+  const [topPosts, setTopPosts] = useState<TopPost[]>([]);
+  const [tagStats, setTagStats] = useState<TagStat[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [days, setDays] = useState(30);
+  const supabase = useMemo(() => createClient(), []);
+
+  const fetchData = useCallback(async () => {
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session?.access_token) return;
+      const token = session.access_token;
+
+      const [ov, daily, top, tags] = await Promise.all([
+        api.stats.getOverview(token),
+        api.stats.getDailyStats(token, days),
+        api.stats.getTopPosts(token),
+        api.stats.getTagStats(token),
+      ]);
+
+      setOverview(ov);
+      setDailyStats(daily);
+      setTopPosts(top);
+      setTagStats(tags);
+    } catch (error) {
+      console.error('Failed to fetch stats:', error);
+    } finally {
+      setLoading(false);
+    }
+  }, [supabase, days]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const maxViews = Math.max(...dailyStats.map((d) => d.views), 1);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+        <div className="mx-auto max-w-6xl px-4 py-8">
+          <div className="space-y-6">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="h-48 animate-pulse rounded-xl bg-gray-200 dark:bg-gray-700" />
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <div className="mx-auto max-w-6xl px-4 py-8 sm:px-6 lg:px-8">
+        <div className="mb-8 flex items-center gap-4">
+          <Link
+            href="/admin"
+            className="rounded-lg p-2 text-gray-500 hover:bg-gray-200 dark:text-gray-400 dark:hover:bg-gray-700"
+          >
+            <ArrowLeft className="h-5 w-5" />
+          </Link>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-white">방문자 통계</h1>
+        </div>
+
+        {overview && (
+          <div className="mb-8 grid grid-cols-2 gap-4 md:grid-cols-4">
+            {[
+              { label: '총 조회수', value: overview.totalViews.toLocaleString(), icon: Eye, color: 'text-blue-500', bg: 'bg-blue-100 dark:bg-blue-900/30' },
+              { label: '오늘 조회수', value: overview.todayViews.toLocaleString(), icon: TrendingUp, color: 'text-green-500', bg: 'bg-green-100 dark:bg-green-900/30' },
+              { label: '발행 글', value: overview.publishedPosts, icon: FileText, color: 'text-purple-500', bg: 'bg-purple-100 dark:bg-purple-900/30' },
+              { label: '임시저장', value: overview.draftPosts, icon: Calendar, color: 'text-orange-500', bg: 'bg-orange-100 dark:bg-orange-900/30' },
+            ].map((item) => (
+              <div key={item.label} className="rounded-xl bg-white p-5 shadow dark:bg-gray-800">
+                <div className="flex items-center gap-3">
+                  <div className={`rounded-lg p-2 ${item.bg}`}>
+                    <item.icon className={`h-5 w-5 ${item.color}`} />
+                  </div>
+                  <div>
+                    <p className="text-xs text-gray-500 dark:text-gray-400">{item.label}</p>
+                    <p className="text-xl font-bold text-gray-900 dark:text-white">{item.value}</p>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className="mb-8 rounded-xl bg-white p-6 shadow dark:bg-gray-800">
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-white">일별 조회수</h2>
+            <div className="flex gap-2">
+              {[7, 14, 30].map((d) => (
+                <button
+                  key={d}
+                  onClick={() => setDays(d)}
+                  className={`rounded-lg px-3 py-1 text-sm ${
+                    days === d
+                      ? 'bg-primary-500 text-white'
+                      : 'bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300'
+                  }`}
+                >
+                  {d}일
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="flex h-48 items-end gap-1">
+            {dailyStats.map((stat) => (
+              <div key={stat.date} className="group relative flex flex-1 flex-col items-center">
+                <div className="absolute -top-8 hidden rounded bg-gray-800 px-2 py-1 text-xs text-white group-hover:block dark:bg-gray-600">
+                  {stat.views}
+                </div>
+                <div
+                  className="w-full rounded-t bg-primary-400 transition-all hover:bg-primary-500 dark:bg-primary-600"
+                  style={{ height: `${Math.max((stat.views / maxViews) * 100, 2)}%` }}
+                />
+              </div>
+            ))}
+          </div>
+          <div className="mt-2 flex justify-between text-xs text-gray-400">
+            <span>{dailyStats[0]?.date?.slice(5)}</span>
+            <span>{dailyStats[dailyStats.length - 1]?.date?.slice(5)}</span>
+          </div>
+        </div>
+
+        <div className="grid gap-8 md:grid-cols-2">
+          <div className="rounded-xl bg-white p-6 shadow dark:bg-gray-800">
+            <h2 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">인기 글 TOP 10</h2>
+            <div className="space-y-3">
+              {topPosts.map((post, index) => (
+                <div key={post.id} className="flex items-center gap-3">
+                  <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-gray-100 text-xs font-bold text-gray-600 dark:bg-gray-700 dark:text-gray-300">
+                    {index + 1}
+                  </span>
+                  <Link
+                    href={`/blog/${post.slug}`}
+                    className="flex-1 truncate text-sm text-gray-700 hover:text-primary-500 dark:text-gray-300"
+                  >
+                    {post.title}
+                  </Link>
+                  <span className="shrink-0 text-sm text-gray-400">
+                    {post.viewCount.toLocaleString()}
+                  </span>
+                </div>
+              ))}
+              {topPosts.length === 0 && (
+                <p className="text-sm text-gray-400">데이터가 없습니다.</p>
+              )}
+            </div>
+          </div>
+
+          <div className="rounded-xl bg-white p-6 shadow dark:bg-gray-800">
+            <h2 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">태그별 통계</h2>
+            <div className="space-y-3">
+              {tagStats.map((tag) => {
+                const maxTagViews = Math.max(...tagStats.map((t) => t.totalViews), 1);
+                return (
+                  <div key={tag.name}>
+                    <div className="mb-1 flex items-center justify-between">
+                      <span className="text-sm text-gray-700 dark:text-gray-300">{tag.name}</span>
+                      <span className="text-xs text-gray-400">
+                        {tag.postCount}글 · {tag.totalViews.toLocaleString()}조회
+                      </span>
+                    </div>
+                    <div className="h-2 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-700">
+                      <div
+                        className="h-full rounded-full bg-primary-400 dark:bg-primary-600"
+                        style={{ width: `${(tag.totalViews / maxTagViews) * 100}%` }}
+                      />
+                    </div>
+                  </div>
+                );
+              })}
+              {tagStats.length === 0 && (
+                <p className="text-sm text-gray-400">데이터가 없습니다.</p>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/stats/page.tsx
+++ b/apps/web/src/app/admin/stats/page.tsx
@@ -163,9 +163,9 @@ export default function AdminStatsPage() {
           <div className="rounded-xl bg-white p-6 shadow dark:bg-gray-800">
             <h2 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">태그별 통계</h2>
             <div className="space-y-3">
-              {tagStats.map((tag) => {
+              {(() => {
                 const maxTagViews = Math.max(...tagStats.map((t) => t.totalViews), 1);
-                return (
+                return tagStats.map((tag) => (
                   <div key={tag.name}>
                     <div className="mb-1 flex items-center justify-between">
                       <span className="text-sm text-gray-700 dark:text-gray-300">{tag.name}</span>
@@ -180,8 +180,8 @@ export default function AdminStatsPage() {
                       />
                     </div>
                   </div>
-                );
-              })}
+                ));
+              })()}
               {tagStats.length === 0 && (
                 <p className="text-sm text-gray-400">데이터가 없습니다.</p>
               )}

--- a/apps/web/src/lib/api/index.ts
+++ b/apps/web/src/lib/api/index.ts
@@ -6,6 +6,7 @@ import { portfolioApi } from './portfolio';
 import { postsApi as blogsApi } from './posts';
 import { tagsApi } from './tags';
 import { usersApi } from './users';
+import { statsApi } from './stats';
 
 export const api = {
   resume: resumeApi,
@@ -13,4 +14,5 @@ export const api = {
   blogs: blogsApi,
   tags: tagsApi,
   users: usersApi,
+  stats: statsApi,
 };

--- a/apps/web/src/lib/api/stats.ts
+++ b/apps/web/src/lib/api/stats.ts
@@ -1,0 +1,50 @@
+import { fetcher } from './client';
+
+export interface DailyStat {
+  date: string;
+  views: number;
+}
+
+export interface TopPost {
+  id: number;
+  title: string;
+  slug: string;
+  viewCount: number;
+  createdAt: string;
+}
+
+export interface TagStat {
+  name: string;
+  postCount: number;
+  totalViews: number;
+}
+
+export interface StatsOverview {
+  totalPosts: number;
+  publishedPosts: number;
+  draftPosts: number;
+  totalViews: number;
+  todayViews: number;
+}
+
+export const statsApi = {
+  getOverview: (token: string) =>
+    fetcher<StatsOverview>('/stats/overview', {
+      headers: { Authorization: `Bearer ${token}` },
+    }),
+
+  getDailyStats: (token: string, days?: number) =>
+    fetcher<DailyStat[]>(`/stats/daily${days ? `?days=${days}` : ''}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    }),
+
+  getTopPosts: (token: string, limit?: number) =>
+    fetcher<TopPost[]>(`/stats/top-posts${limit ? `?limit=${limit}` : ''}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    }),
+
+  getTagStats: (token: string) =>
+    fetcher<TagStat[]>('/stats/tags', {
+      headers: { Authorization: `Bearer ${token}` },
+    }),
+};


### PR DESCRIPTION
## 변경 사항

- DB: DailyStats 모델 추가 (일별 페이지별 조회수 집계)
- 백엔드: Stats 모듈 구현 (overview, daily, top-posts, tags API 엔드포인트)
- 게시글 조회수 증가 시 DailyStats 테이블에 일별 통계 자동 기록
- 프론트: 통계 대시보드 페이지 (/admin/stats) - 일별 조회수 차트, 인기글 TOP 10, 태그별 통계
- 어드민 메뉴에 방문자 통계 항목 추가

## 변경된 파일

- `apps/api/prisma/schema.prisma` (+15)
- `apps/api/src/app.module.ts` (+2)
- `apps/api/src/posts/posts.module.ts` (+2)
- `apps/api/src/posts/posts.service.ts` (+9/-1)
- `apps/api/src/stats/` (신규 모듈 - controller, service, module) (+152)
- `apps/web/src/app/admin/page.tsx` (+7/-3)
- `apps/web/src/app/admin/stats/page.tsx` (+194)
- `apps/web/src/lib/api/index.ts` (+2)
- `apps/web/src/lib/api/stats.ts` (+50)

## 관련 이슈

- Closes #64

## 테스트

- [ ] 로컬에서 테스트 완료
- [ ] 빌드 성공 확인

## 체크리스트

- [ ] 코드 리뷰 완료
- [ ] 타입 체크 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **통계 대시보드 추가**
  * 관리자 패널에 통계 페이지 추가
  * 일일 조회수 추세, 인기 게시물, 태그별 통계, 전체 개요 정보 조회 가능
  * 통계 기간을 7/14/30일 중 선택하여 조회 가능
  * 게시물 조회수 자동 추적 기능 구현

<!-- end of auto-generated comment: release notes by coderabbit.ai -->