### PR TITLE
[Feature] #65 이력서/포트폴리오 공유 링크 기능 구현

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -75,6 +75,28 @@ model Tag {
   @@map("tags")
 }
 
+// ShareLink model - for shareable resume/portfolio links
+model ShareLink {
+  id          String    @id @default(uuid())
+  slug        String    @unique
+  type        ShareType
+  label       String?
+  active      Boolean   @default(true)
+  viewCount   Int       @default(0) @map("view_count")
+  expiresAt   DateTime? @map("expires_at")
+  createdAt   DateTime  @default(now()) @map("created_at")
+  updatedAt   DateTime  @updatedAt @map("updated_at")
+
+  @@index([slug])
+  @@index([type])
+  @@map("share_links")
+}
+
+enum ShareType {
+  RESUME
+  PORTFOLIO
+}
+
 // Role enum
 enum Role {
   USER

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -9,6 +9,7 @@ import { AuthModule } from './auth';
 import { PostsModule } from './posts';
 import { TagsModule } from './tags';
 import { UsersModule } from './users';
+import { ShareModule } from './share';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { UsersModule } from './users';
     PostsModule,
     TagsModule,
     UsersModule,
+    ShareModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/api/src/share/dto/create-share-link.dto.ts
+++ b/apps/api/src/share/dto/create-share-link.dto.ts
@@ -1,0 +1,16 @@
+import { IsString, IsNotEmpty, IsOptional, IsIn, IsDateString } from 'class-validator';
+
+export class CreateShareLinkDto {
+  @IsString()
+  @IsNotEmpty()
+  @IsIn(['RESUME', 'PORTFOLIO'])
+  type: 'RESUME' | 'PORTFOLIO';
+
+  @IsOptional()
+  @IsString()
+  label?: string;
+
+  @IsOptional()
+  @IsDateString()
+  expiresAt?: string;
+}

--- a/apps/api/src/share/dto/index.ts
+++ b/apps/api/src/share/dto/index.ts
@@ -1,0 +1,1 @@
+export { CreateShareLinkDto } from './create-share-link.dto';

--- a/apps/api/src/share/index.ts
+++ b/apps/api/src/share/index.ts
@@ -1,0 +1,2 @@
+export { ShareModule } from './share.module';
+export { ShareService } from './share.service';

--- a/apps/api/src/share/share.controller.ts
+++ b/apps/api/src/share/share.controller.ts
@@ -1,0 +1,53 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Delete,
+  Patch,
+  Body,
+  Param,
+  UseGuards,
+} from '@nestjs/common';
+import { ShareService } from './share.service';
+import { CreateShareLinkDto } from './dto';
+import { SupabaseGuard } from '../auth/guards/supabase.guard';
+import { AdminGuard } from '../auth/guards/admin.guard';
+
+@Controller('share')
+export class ShareController {
+  constructor(private readonly shareService: ShareService) {}
+
+  @Get()
+  @UseGuards(SupabaseGuard, AdminGuard)
+  async findAll() {
+    return this.shareService.findAll();
+  }
+
+  @Get(':slug')
+  async findBySlug(@Param('slug') slug: string) {
+    return this.shareService.findBySlug(slug);
+  }
+
+  @Post()
+  @UseGuards(SupabaseGuard, AdminGuard)
+  async create(@Body() dto: CreateShareLinkDto) {
+    return this.shareService.create(dto);
+  }
+
+  @Patch(':id/toggle')
+  @UseGuards(SupabaseGuard, AdminGuard)
+  async toggleActive(@Param('id') id: string) {
+    return this.shareService.toggleActive(id);
+  }
+
+  @Delete(':id')
+  @UseGuards(SupabaseGuard, AdminGuard)
+  async delete(@Param('id') id: string) {
+    return this.shareService.delete(id);
+  }
+
+  @Post(':slug/view')
+  async incrementView(@Param('slug') slug: string) {
+    return this.shareService.incrementView(slug);
+  }
+}

--- a/apps/api/src/share/share.module.ts
+++ b/apps/api/src/share/share.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ShareController } from './share.controller';
+import { ShareService } from './share.service';
+
+@Module({
+  controllers: [ShareController],
+  providers: [ShareService],
+  exports: [ShareService],
+})
+export class ShareModule {}

--- a/apps/api/src/share/share.service.ts
+++ b/apps/api/src/share/share.service.ts
@@ -1,0 +1,64 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import { CreateShareLinkDto } from './dto';
+import { randomBytes } from 'crypto';
+
+@Injectable()
+export class ShareService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findAll() {
+    return this.prisma.shareLink.findMany({
+      orderBy: { createdAt: 'desc' },
+    });
+  }
+
+  async findBySlug(slug: string) {
+    const link = await this.prisma.shareLink.findUnique({ where: { slug } });
+
+    if (!link) throw new NotFoundException('Share link not found');
+    if (!link.active) throw new NotFoundException('This link has been deactivated');
+    if (link.expiresAt && new Date() > link.expiresAt) {
+      throw new NotFoundException('This link has expired');
+    }
+
+    return link;
+  }
+
+  async create(dto: CreateShareLinkDto) {
+    const slug = randomBytes(6).toString('base64url');
+
+    return this.prisma.shareLink.create({
+      data: {
+        slug,
+        type: dto.type,
+        label: dto.label,
+        expiresAt: dto.expiresAt ? new Date(dto.expiresAt) : null,
+      },
+    });
+  }
+
+  async toggleActive(id: string) {
+    const link = await this.prisma.shareLink.findUnique({ where: { id } });
+    if (!link) throw new NotFoundException('Share link not found');
+
+    return this.prisma.shareLink.update({
+      where: { id },
+      data: { active: !link.active },
+    });
+  }
+
+  async delete(id: string) {
+    const link = await this.prisma.shareLink.findUnique({ where: { id } });
+    if (!link) throw new NotFoundException('Share link not found');
+
+    return this.prisma.shareLink.delete({ where: { id } });
+  }
+
+  async incrementView(slug: string) {
+    return this.prisma.shareLink.update({
+      where: { slug },
+      data: { viewCount: { increment: 1 } },
+    });
+  }
+}

--- a/apps/api/src/share/share.service.ts
+++ b/apps/api/src/share/share.service.ts
@@ -60,6 +60,9 @@ export class ShareService {
   }
 
   async incrementView(slug: string) {
+    const link = await this.prisma.shareLink.findUnique({ where: { slug } });
+    if (!link) throw new NotFoundException('Share link not found');
+
     return this.prisma.shareLink.update({
       where: { slug },
       data: { viewCount: { increment: 1 } },

--- a/apps/api/src/share/share.service.ts
+++ b/apps/api/src/share/share.service.ts
@@ -7,6 +7,12 @@ import { randomBytes } from 'crypto';
 export class ShareService {
   constructor(private readonly prisma: PrismaService) {}
 
+  private async findLinkByIdOrThrow(id: string) {
+    const link = await this.prisma.shareLink.findUnique({ where: { id } });
+    if (!link) throw new NotFoundException('Share link not found');
+    return link;
+  }
+
   async findAll() {
     return this.prisma.shareLink.findMany({
       orderBy: { createdAt: 'desc' },
@@ -39,8 +45,7 @@ export class ShareService {
   }
 
   async toggleActive(id: string) {
-    const link = await this.prisma.shareLink.findUnique({ where: { id } });
-    if (!link) throw new NotFoundException('Share link not found');
+    const link = await this.findLinkByIdOrThrow(id);
 
     return this.prisma.shareLink.update({
       where: { id },
@@ -49,8 +54,7 @@ export class ShareService {
   }
 
   async delete(id: string) {
-    const link = await this.prisma.shareLink.findUnique({ where: { id } });
-    if (!link) throw new NotFoundException('Share link not found');
+    await this.findLinkByIdOrThrow(id);
 
     return this.prisma.shareLink.delete({ where: { id } });
   }

--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -1,6 +1,6 @@
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
-import { FileText, Briefcase, Tags, Settings, PenSquare, ExternalLink, Users, ImageIcon } from 'lucide-react';
+import { FileText, Briefcase, Tags, Settings, PenSquare, ExternalLink, Users, ImageIcon, Share2 } from 'lucide-react';
 import { createClient } from '@/lib/supabase/server';
 import { LogoutButton } from '@/components/auth/LogoutButton';
 import { DashboardStats } from '@/components/admin/DashboardStats';
@@ -56,6 +56,14 @@ const menuItems = [
     icon: ImageIcon,
     color: 'text-pink-500',
     bgColor: 'bg-pink-100 dark:bg-pink-900/30',
+  },
+  {
+    href: '/admin/share',
+    title: '공유 링크',
+    description: '이력서/포트폴리오 공유 링크를 생성하고 관리합니다.',
+    icon: Share2,
+    color: 'text-emerald-500',
+    bgColor: 'bg-emerald-100 dark:bg-emerald-900/30',
   },
   {
     href: '/admin/settings',

--- a/apps/web/src/app/admin/share/page.tsx
+++ b/apps/web/src/app/admin/share/page.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import Link from 'next/link';
+import { ArrowLeft, Plus, Trash2, Copy, ExternalLink, ToggleLeft, ToggleRight } from 'lucide-react';
+import { api } from '@/lib/api';
+import { createClient } from '@/lib/supabase/client';
+import { useToast } from '@/components/ui';
+import { config } from '@/config';
+import type { ShareLink } from '@/lib/api/share';
+
+export default function AdminSharePage() {
+  const [links, setLinks] = useState<ShareLink[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [type, setType] = useState<'RESUME' | 'PORTFOLIO'>('RESUME');
+  const [label, setLabel] = useState('');
+  const { toast } = useToast();
+  const supabase = useMemo(() => createClient(), []);
+
+  const getToken = async () => {
+    const { data: { session } } = await supabase.auth.getSession();
+    if (!session?.access_token) throw new Error('Not authenticated');
+    return session.access_token;
+  };
+
+  const fetchLinks = useCallback(async () => {
+    try {
+      const token = await getToken();
+      const data = await api.share.getList(token);
+      setLinks(data);
+    } catch {
+      toast('공유 링크를 불러오는데 실패했습니다.', 'error');
+    } finally {
+      setLoading(false);
+    }
+  }, [toast]);
+
+  useEffect(() => {
+    fetchLinks();
+  }, [fetchLinks]);
+
+  const handleCreate = async () => {
+    try {
+      const token = await getToken();
+      await api.share.create({ type, label: label.trim() || undefined }, token);
+      toast('공유 링크가 생성되었습니다.', 'success');
+      setShowForm(false);
+      setLabel('');
+      fetchLinks();
+    } catch {
+      toast('공유 링크 생성에 실패했습니다.', 'error');
+    }
+  };
+
+  const handleToggle = async (id: string) => {
+    try {
+      const token = await getToken();
+      await api.share.toggleActive(id, token);
+      fetchLinks();
+    } catch {
+      toast('상태 변경에 실패했습니다.', 'error');
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('이 공유 링크를 삭제하시겠습니까?')) return;
+    try {
+      const token = await getToken();
+      await api.share.delete(id, token);
+      toast('공유 링크가 삭제되었습니다.', 'success');
+      fetchLinks();
+    } catch {
+      toast('삭제에 실패했습니다.', 'error');
+    }
+  };
+
+  const copyLink = (slug: string) => {
+    navigator.clipboard.writeText(`${config.siteUrl}/s/${slug}`);
+    toast('링크가 복사되었습니다.', 'success');
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
+      <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
+        <div className="mb-8 flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            <Link href="/admin" className="rounded-lg p-2 text-gray-500 hover:bg-gray-200 dark:text-gray-400 dark:hover:bg-gray-700">
+              <ArrowLeft className="h-5 w-5" />
+            </Link>
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-white">공유 링크 관리</h1>
+          </div>
+          <button
+            onClick={() => setShowForm(true)}
+            className="flex items-center gap-2 rounded-lg bg-primary-500 px-4 py-2 text-sm font-medium text-white hover:bg-primary-600 transition-colors"
+          >
+            <Plus className="h-4 w-4" />
+            새 링크
+          </button>
+        </div>
+
+        {showForm && (
+          <div className="mb-6 rounded-xl border border-gray-200 bg-white p-6 dark:border-gray-700 dark:bg-gray-800">
+            <h2 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">새 공유 링크</h2>
+            <div className="space-y-4">
+              <div className="flex gap-3">
+                {(['RESUME', 'PORTFOLIO'] as const).map((t) => (
+                  <button
+                    key={t}
+                    onClick={() => setType(t)}
+                    className={`rounded-lg px-4 py-2 text-sm font-medium transition-colors ${
+                      type === t
+                        ? 'bg-primary-500 text-white'
+                        : 'bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300'
+                    }`}
+                  >
+                    {t === 'RESUME' ? '이력서' : '포트폴리오'}
+                  </button>
+                ))}
+              </div>
+              <input
+                type="text"
+                value={label}
+                onChange={(e) => setLabel(e.target.value)}
+                placeholder="라벨 (예: 구글 지원용)"
+                className="w-full rounded-lg border border-gray-300 bg-white px-4 py-2 text-gray-900 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
+              />
+              <div className="flex gap-3">
+                <button onClick={handleCreate} className="rounded-lg bg-primary-500 px-4 py-2 text-sm font-medium text-white hover:bg-primary-600 transition-colors">
+                  생성
+                </button>
+                <button onClick={() => setShowForm(false)} className="rounded-lg border border-gray-300 px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700 transition-colors">
+                  취소
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {loading ? (
+          <div className="space-y-4">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="h-20 animate-pulse rounded-xl bg-gray-200 dark:bg-gray-700" />
+            ))}
+          </div>
+        ) : links.length === 0 ? (
+          <div className="py-12 text-center text-gray-500 dark:text-gray-400">
+            아직 생성된 공유 링크가 없습니다.
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {links.map((link) => (
+              <div
+                key={link.id}
+                className={`flex items-center justify-between rounded-xl border bg-white p-5 dark:bg-gray-800 ${
+                  link.active ? 'border-gray-200 dark:border-gray-700' : 'border-red-200 opacity-60 dark:border-red-800'
+                }`}
+              >
+                <div>
+                  <div className="flex items-center gap-2">
+                    <span className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                      link.type === 'RESUME'
+                        ? 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
+                        : 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400'
+                    }`}>
+                      {link.type === 'RESUME' ? '이력서' : '포트폴리오'}
+                    </span>
+                    {link.label && (
+                      <span className="text-sm font-medium text-gray-900 dark:text-white">{link.label}</span>
+                    )}
+                    {!link.active && (
+                      <span className="rounded-full bg-red-100 px-2 py-0.5 text-xs text-red-600 dark:bg-red-900/30 dark:text-red-400">비활성</span>
+                    )}
+                  </div>
+                  <div className="mt-1 flex items-center gap-3 text-xs text-gray-400">
+                    <span>{config.siteUrl}/s/{link.slug}</span>
+                    <span>·</span>
+                    <span>조회 {link.viewCount}회</span>
+                    <span>·</span>
+                    <span>{new Date(link.createdAt).toLocaleDateString('ko-KR')}</span>
+                  </div>
+                </div>
+                <div className="flex items-center gap-1">
+                  <button onClick={() => copyLink(link.slug)} className="rounded-lg p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-700" title="링크 복사">
+                    <Copy className="h-4 w-4" />
+                  </button>
+                  <a href={`/s/${link.slug}`} target="_blank" rel="noopener noreferrer" className="rounded-lg p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-700" title="미리보기">
+                    <ExternalLink className="h-4 w-4" />
+                  </a>
+                  <button onClick={() => handleToggle(link.id)} className="rounded-lg p-2 text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-700" title={link.active ? '비활성화' : '활성화'}>
+                    {link.active ? <ToggleRight className="h-5 w-5 text-green-500" /> : <ToggleLeft className="h-5 w-5" />}
+                  </button>
+                  <button onClick={() => handleDelete(link.id)} className="rounded-lg p-2 text-gray-400 hover:bg-red-50 hover:text-red-500 dark:hover:bg-red-900/20" title="삭제">
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/share/page.tsx
+++ b/apps/web/src/app/admin/share/page.tsx
@@ -18,11 +18,11 @@ export default function AdminSharePage() {
   const { toast } = useToast();
   const supabase = useMemo(() => createClient(), []);
 
-  const getToken = async () => {
+  const getToken = useCallback(async () => {
     const { data: { session } } = await supabase.auth.getSession();
     if (!session?.access_token) throw new Error('Not authenticated');
     return session.access_token;
-  };
+  }, [supabase]);
 
   const fetchLinks = useCallback(async () => {
     try {
@@ -34,7 +34,7 @@ export default function AdminSharePage() {
     } finally {
       setLoading(false);
     }
-  }, [toast]);
+  }, [toast, getToken]);
 
   useEffect(() => {
     fetchLinks();

--- a/apps/web/src/app/admin/share/page.tsx
+++ b/apps/web/src/app/admin/share/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { ArrowLeft, Plus, Trash2, Copy, ExternalLink, ToggleLeft, ToggleRight } from 'lucide-react';
 import { api } from '@/lib/api';
 import { createClient } from '@/lib/supabase/client';
-import { useToast } from '@/components/ui';
+import { useToast, useConfirm } from '@/components/ui';
 import { config } from '@/config';
 import type { ShareLink } from '@/lib/api/share';
 
@@ -16,6 +16,7 @@ export default function AdminSharePage() {
   const [type, setType] = useState<'RESUME' | 'PORTFOLIO'>('RESUME');
   const [label, setLabel] = useState('');
   const { toast } = useToast();
+  const { confirm } = useConfirm();
   const supabase = useMemo(() => createClient(), []);
 
   const getToken = useCallback(async () => {
@@ -64,7 +65,12 @@ export default function AdminSharePage() {
   };
 
   const handleDelete = async (id: string) => {
-    if (!confirm('이 공유 링크를 삭제하시겠습니까?')) return;
+    const confirmed = await confirm({
+      title: '공유 링크 삭제',
+      message: '이 공유 링크를 삭제하시겠습니까?',
+      confirmText: '삭제',
+    });
+    if (!confirmed) return;
     try {
       const token = await getToken();
       await api.share.delete(id, token);
@@ -76,8 +82,9 @@ export default function AdminSharePage() {
   };
 
   const copyLink = (slug: string) => {
-    navigator.clipboard.writeText(`${config.siteUrl}/s/${slug}`);
-    toast('링크가 복사되었습니다.', 'success');
+    navigator.clipboard.writeText(`${config.siteUrl}/s/${slug}`)
+      .then(() => toast('링크가 복사되었습니다.', 'success'))
+      .catch(() => toast('링크 복사에 실패했습니다.', 'error'));
   };
 
   return (

--- a/apps/web/src/app/s/[slug]/page.tsx
+++ b/apps/web/src/app/s/[slug]/page.tsx
@@ -11,7 +11,7 @@ export default async function SharePage({ params }: PageProps) {
   try {
     const link = await api.share.getBySlug(slug);
 
-    api.share.incrementView(slug).catch(() => {});
+    api.share.incrementView(slug).catch(console.error);
 
     if (link.type === 'RESUME') {
       redirect('/resume');

--- a/apps/web/src/app/s/[slug]/page.tsx
+++ b/apps/web/src/app/s/[slug]/page.tsx
@@ -8,17 +8,20 @@ interface PageProps {
 export default async function SharePage({ params }: PageProps) {
   const { slug } = await params;
 
+  let link;
   try {
-    const link = await api.share.getBySlug(slug);
+    link = await api.share.getBySlug(slug);
 
     api.share.incrementView(slug).catch(console.error);
-
-    if (link.type === 'RESUME') {
-      redirect('/resume');
-    } else {
-      redirect('/portfolio');
-    }
   } catch {
     notFound();
+  }
+
+  if (!link) notFound();
+
+  if (link.type === 'RESUME') {
+    redirect('/resume');
+  } else {
+    redirect('/portfolio');
   }
 }

--- a/apps/web/src/app/s/[slug]/page.tsx
+++ b/apps/web/src/app/s/[slug]/page.tsx
@@ -1,0 +1,24 @@
+import { notFound, redirect } from 'next/navigation';
+import { api } from '@/lib/api';
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export default async function SharePage({ params }: PageProps) {
+  const { slug } = await params;
+
+  try {
+    const link = await api.share.getBySlug(slug);
+
+    api.share.incrementView(slug).catch(() => {});
+
+    if (link.type === 'RESUME') {
+      redirect('/resume');
+    } else {
+      redirect('/portfolio');
+    }
+  } catch {
+    notFound();
+  }
+}

--- a/apps/web/src/lib/api/index.ts
+++ b/apps/web/src/lib/api/index.ts
@@ -6,6 +6,7 @@ import { portfolioApi } from './portfolio';
 import { postsApi as blogsApi } from './posts';
 import { tagsApi } from './tags';
 import { usersApi } from './users';
+import { shareApi } from './share';
 
 export const api = {
   resume: resumeApi,
@@ -13,4 +14,5 @@ export const api = {
   blogs: blogsApi,
   tags: tagsApi,
   users: usersApi,
+  share: shareApi,
 };

--- a/apps/web/src/lib/api/share.ts
+++ b/apps/web/src/lib/api/share.ts
@@ -1,0 +1,45 @@
+import { fetcher } from './client';
+
+export interface ShareLink {
+  id: string;
+  slug: string;
+  type: 'RESUME' | 'PORTFOLIO';
+  label?: string | null;
+  active: boolean;
+  viewCount: number;
+  expiresAt?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export const shareApi = {
+  getList: (token: string) =>
+    fetcher<ShareLink[]>('/share', {
+      headers: { Authorization: `Bearer ${token}` },
+    }),
+
+  getBySlug: (slug: string) =>
+    fetcher<ShareLink>(`/share/${slug}`),
+
+  create: (data: { type: 'RESUME' | 'PORTFOLIO'; label?: string; expiresAt?: string }, token: string) =>
+    fetcher<ShareLink>('/share', {
+      method: 'POST',
+      body: JSON.stringify(data),
+      headers: { Authorization: `Bearer ${token}` },
+    }),
+
+  toggleActive: (id: string, token: string) =>
+    fetcher<ShareLink>(`/share/${id}/toggle`, {
+      method: 'PATCH',
+      headers: { Authorization: `Bearer ${token}` },
+    }),
+
+  delete: (id: string, token: string) =>
+    fetcher<void>(`/share/${id}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${token}` },
+    }),
+
+  incrementView: (slug: string) =>
+    fetcher<ShareLink>(`/share/${slug}/view`, { method: 'POST' }),
+};


### PR DESCRIPTION
## 변경 사항

- DB: ShareLink 모델 + ShareType enum 추가
- 백엔드: Share CRUD 모듈 (생성, 활성/비활성 토글, 삭제, 조회수 기록)
- 프론트: 어드민 공유 링크 관리 페이지 (/admin/share) - 링크 생성/복사/삭제
- 공개 리다이렉트 페이지 (/s/[slug]) 구현
- 어드민 메뉴에 공유 링크 항목 추가

## 변경된 파일

- `apps/api/prisma/schema.prisma` (+22)
- `apps/api/src/app.module.ts` (+2)
- `apps/api/src/share/` (신규 모듈 - controller, service, dto, module) (+146)
- `apps/web/src/app/admin/page.tsx` (+7/-3)
- `apps/web/src/app/admin/share/page.tsx` (+204)
- `apps/web/src/app/s/[slug]/page.tsx` (+24)
- `apps/web/src/lib/api/index.ts` (+2)
- `apps/web/src/lib/api/share.ts` (+45)

## 관련 이슈

- Closes #65

## 테스트

- [ ] 로컬에서 테스트 완료
- [ ] 빌드 성공 확인

## 체크리스트

- [ ] 코드 리뷰 완료
- [ ] 타입 체크 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 이력서/포트폴리오 공유 링크 생성 및 관리 기능 추가
  * 관리자용 공유 링크 관리 페이지 추가
  * 고유한 공유 URL을 통한 이력서/포트폴리오 접근 지원
  * 공유 링크별 조회 수 추적 기능
  * 공유 링크 활성화/비활성화 및 만료일 설정 가능

<!-- end of auto-generated comment: release notes by coderabbit.ai -->