### PR TITLE
[Feature] #67 블로그 글 임시 저장(Auto-save) 기능 구현

### DIFF
--- a/apps/web/src/components/post/DraftBanner.tsx
+++ b/apps/web/src/components/post/DraftBanner.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+interface DraftBannerProps {
+  savedAt: string;
+  onRestore: () => void;
+  onDiscard: () => void;
+}
+
+export function DraftBanner({ savedAt, onRestore, onDiscard }: DraftBannerProps) {
+  const timeStr = new Date(savedAt).toLocaleString('ko-KR', {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
+  return (
+    <div className="flex items-center justify-between rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-800 dark:bg-amber-900/20">
+      <p className="text-sm text-amber-700 dark:text-amber-400">
+        임시 저장된 글이 있습니다. ({timeStr})
+      </p>
+      <div className="flex gap-2">
+        <button
+          onClick={onRestore}
+          className="rounded-md bg-amber-500 px-3 py-1 text-xs font-medium text-white hover:bg-amber-600 transition-colors"
+        >
+          복원
+        </button>
+        <button
+          onClick={onDiscard}
+          className="rounded-md border border-amber-300 px-3 py-1 text-xs font-medium text-amber-700 hover:bg-amber-100 dark:border-amber-700 dark:text-amber-400 dark:hover:bg-amber-900/40 transition-colors"
+        >
+          삭제
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/post/PostEditor.tsx
+++ b/apps/web/src/components/post/PostEditor.tsx
@@ -45,7 +45,11 @@ export function PostEditor({ initialData, onSave, saving }: PostEditorProps) {
     useAutoSave({ postId: initialData?.id });
 
   // 초기 상태 설정 및 드래프트 확인
+  const initializedRef = useRef(false);
   useEffect(() => {
+    if (initializedRef.current) return;
+    initializedRef.current = true;
+
     const initial = {
       title: initialData?.title || '',
       content: initialData?.content || '',
@@ -60,8 +64,7 @@ export function PostEditor({ initialData, onSave, saving }: PostEditorProps) {
       setDraftAvailable(true);
       setDraftSavedAt(draft.savedAt);
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [initialData, setInitialState, loadDraft]);
 
   // 상태 변경 시 auto-save에 반영
   useEffect(() => {

--- a/apps/web/src/components/post/PostEditor.tsx
+++ b/apps/web/src/components/post/PostEditor.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import dynamic from 'next/dynamic';
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { TagSelector } from './TagSelector';
 import { MarkdownImageButton } from './MarkdownImageButton';
+import { DraftBanner } from './DraftBanner';
 import { useTags } from '@/hooks/useTags';
 import { useMarkdownImage } from '@/hooks/useMarkdownImage';
+import { useAutoSave } from '@/hooks/useAutoSave';
 import { useToast, ImageUpload } from '@/components/ui';
 import type { CreatePostDto, Post } from '@/types/post';
 
@@ -35,6 +37,54 @@ export function PostEditor({ initialData, onSave, saving }: PostEditorProps) {
     }
     return '';
   });
+  const [draftAvailable, setDraftAvailable] = useState(false);
+  const [draftSavedAt, setDraftSavedAt] = useState<string | null>(null);
+
+  // 임시 저장 훅
+  const { updateState, setInitialState, save: saveDraftNow, load: loadDraft, discard: discardDraft, lastSaved } =
+    useAutoSave({ postId: initialData?.id });
+
+  // 초기 상태 설정 및 드래프트 확인
+  useEffect(() => {
+    const initial = {
+      title: initialData?.title || '',
+      content: initialData?.content || '',
+      excerpt: initialData?.excerpt || '',
+      coverImage: initialData?.coverImage || '',
+      tagIds: initialData?.tags.map((t) => t.id) || [],
+    };
+    setInitialState(initial);
+
+    const draft = loadDraft();
+    if (draft && draft.savedAt) {
+      setDraftAvailable(true);
+      setDraftSavedAt(draft.savedAt);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // 상태 변경 시 auto-save에 반영
+  useEffect(() => {
+    updateState({ title, content, excerpt, coverImage, tagIds: selectedTagIds });
+  }, [title, content, excerpt, coverImage, selectedTagIds, updateState]);
+
+  const handleRestoreDraft = useCallback(() => {
+    const draft = loadDraft();
+    if (!draft) return;
+    setTitle(draft.title);
+    setContent(draft.content);
+    setExcerpt(draft.excerpt);
+    setCoverImage(draft.coverImage);
+    if (draft.tagIds?.length) setSelectedTagIds(draft.tagIds);
+    setDraftAvailable(false);
+    toast('임시 저장된 글을 복원했습니다.', 'success');
+  }, [loadDraft, toast]);
+
+  const handleDiscardDraft = useCallback(() => {
+    discardDraft();
+    setDraftAvailable(false);
+    toast('임시 저장을 삭제했습니다.', 'info');
+  }, [discardDraft, toast]);
 
   // 마크다운 이미지 업로드 훅
   const { uploading, handleFileUpload, bindDropEvents, bindPasteEvents } =
@@ -73,10 +123,19 @@ export function PostEditor({ initialData, onSave, saving }: PostEditorProps) {
     };
 
     await onSave(data);
+    discardDraft();
   };
 
   return (
     <div className="space-y-6">
+      {draftAvailable && draftSavedAt && (
+        <DraftBanner
+          savedAt={draftSavedAt}
+          onRestore={handleRestoreDraft}
+          onDiscard={handleDiscardDraft}
+        />
+      )}
+
       <div>
         <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
           제목
@@ -170,19 +229,32 @@ export function PostEditor({ initialData, onSave, saving }: PostEditorProps) {
       </div>
 
       <div className="flex items-center justify-between pt-4 border-t border-gray-200 dark:border-gray-700">
-        <label className="flex items-center gap-2">
-          <input
-            type="checkbox"
-            checked={published}
-            onChange={(e) => setPublished(e.target.checked)}
-            className="rounded border-gray-300 dark:border-gray-600"
-          />
-          <span className="text-sm text-gray-700 dark:text-gray-300">
-            바로 발행하기
-          </span>
-        </label>
+        <div className="flex items-center gap-4">
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={published}
+              onChange={(e) => setPublished(e.target.checked)}
+              className="rounded border-gray-300 dark:border-gray-600"
+            />
+            <span className="text-sm text-gray-700 dark:text-gray-300">
+              바로 발행하기
+            </span>
+          </label>
+          {lastSaved && (
+            <span className="text-xs text-gray-400 dark:text-gray-500">
+              자동 저장됨 {new Date(lastSaved).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })}
+            </span>
+          )}
+        </div>
 
         <div className="flex gap-3">
+          <button
+            onClick={() => { saveDraftNow(); toast('임시 저장되었습니다.', 'info'); }}
+            className="px-3 py-2 text-xs border border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
+          >
+            로컬 저장
+          </button>
           <button
             onClick={() => handleSave(false)}
             disabled={saving}

--- a/apps/web/src/components/post/PostEditor.tsx
+++ b/apps/web/src/components/post/PostEditor.tsx
@@ -66,8 +66,9 @@ export function PostEditor({ initialData, onSave, saving }: PostEditorProps) {
     }
   }, [initialData, setInitialState, loadDraft]);
 
-  // 상태 변경 시 auto-save에 반영
+  // 상태 변경 시 auto-save에 반영 (초기화 완료 후에만)
   useEffect(() => {
+    if (!initializedRef.current) return;
     updateState({ title, content, excerpt, coverImage, tagIds: selectedTagIds });
   }, [title, content, excerpt, coverImage, selectedTagIds, updateState]);
 
@@ -253,7 +254,7 @@ export function PostEditor({ initialData, onSave, saving }: PostEditorProps) {
 
         <div className="flex gap-3">
           <button
-            onClick={() => { saveDraftNow(); toast('임시 저장되었습니다.', 'info'); }}
+            onClick={() => { const saved = saveDraftNow(); toast(saved ? '임시 저장되었습니다.' : '변경 사항이 없습니다.', saved ? 'info' : 'warning'); }}
             className="px-3 py-2 text-xs border border-gray-200 dark:border-gray-700 text-gray-500 dark:text-gray-400 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
           >
             로컬 저장

--- a/apps/web/src/hooks/useAutoSave.ts
+++ b/apps/web/src/hooks/useAutoSave.ts
@@ -25,7 +25,9 @@ export function useAutoSave({ postId, interval = 30000 }: UseAutoSaveOptions = {
 
   const updateState = useCallback((state: AutoSaveState) => {
     stateRef.current = state;
-    isDirtyRef.current = JSON.stringify(state) !== initialStateRef.current;
+    // 매 키 입력마다 JSON.stringify 비교하지 않고 dirty 플래그만 설정
+    // 실제 비교는 save 시점에 수행
+    isDirtyRef.current = true;
   }, []);
 
   const setInitialState = useCallback((state: AutoSaveState) => {
@@ -36,6 +38,11 @@ export function useAutoSave({ postId, interval = 30000 }: UseAutoSaveOptions = {
 
   const save = useCallback(() => {
     if (!isDirtyRef.current) return;
+    // save 시점에 실제 변경 여부 확인
+    if (JSON.stringify(stateRef.current) === initialStateRef.current) {
+      isDirtyRef.current = false;
+      return;
+    }
     const { title, content } = stateRef.current;
     if (!title.trim() && !content.trim()) return;
 

--- a/apps/web/src/hooks/useAutoSave.ts
+++ b/apps/web/src/hooks/useAutoSave.ts
@@ -1,0 +1,77 @@
+'use client';
+
+import { useEffect, useRef, useCallback, useState } from 'react';
+import { saveDraft, loadDraft, deleteDraft } from '@/utils/draft';
+import type { DraftData } from '@/utils/draft';
+
+interface UseAutoSaveOptions {
+  postId?: number;
+  interval?: number; // ms, default 30s
+}
+
+interface AutoSaveState {
+  title: string;
+  content: string;
+  excerpt: string;
+  coverImage: string;
+  tagIds: string[];
+}
+
+export function useAutoSave({ postId, interval = 30000 }: UseAutoSaveOptions = {}) {
+  const [lastSaved, setLastSaved] = useState<string | null>(null);
+  const stateRef = useRef<AutoSaveState>({ title: '', content: '', excerpt: '', coverImage: '', tagIds: [] });
+  const initialStateRef = useRef<string>('');
+  const isDirtyRef = useRef(false);
+
+  const updateState = useCallback((state: AutoSaveState) => {
+    stateRef.current = state;
+    isDirtyRef.current = JSON.stringify(state) !== initialStateRef.current;
+  }, []);
+
+  const setInitialState = useCallback((state: AutoSaveState) => {
+    initialStateRef.current = JSON.stringify(state);
+    stateRef.current = state;
+    isDirtyRef.current = false;
+  }, []);
+
+  const save = useCallback(() => {
+    if (!isDirtyRef.current) return;
+    const { title, content } = stateRef.current;
+    if (!title.trim() && !content.trim()) return;
+
+    saveDraft(stateRef.current, postId);
+    setLastSaved(new Date().toISOString());
+  }, [postId]);
+
+  const load = useCallback((): DraftData | null => {
+    return loadDraft(postId);
+  }, [postId]);
+
+  const discard = useCallback(() => {
+    deleteDraft(postId);
+    setLastSaved(null);
+    isDirtyRef.current = false;
+  }, [postId]);
+
+  // Auto-save interval
+  useEffect(() => {
+    const timer = setInterval(() => {
+      save();
+    }, interval);
+
+    return () => clearInterval(timer);
+  }, [save, interval]);
+
+  // beforeunload warning
+  useEffect(() => {
+    const handler = (e: BeforeUnloadEvent) => {
+      if (isDirtyRef.current) {
+        e.preventDefault();
+      }
+    };
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, []);
+
+  return { updateState, setInitialState, save, load, discard, lastSaved };
+}

--- a/apps/web/src/hooks/useAutoSave.ts
+++ b/apps/web/src/hooks/useAutoSave.ts
@@ -43,6 +43,9 @@ export function useAutoSave({ postId, interval = 30000 }: UseAutoSaveOptions = {
     setLastSaved(new Date().toISOString());
   }, [postId]);
 
+  const saveRef = useRef(save);
+  saveRef.current = save;
+
   const load = useCallback((): DraftData | null => {
     return loadDraft(postId);
   }, [postId]);
@@ -56,11 +59,11 @@ export function useAutoSave({ postId, interval = 30000 }: UseAutoSaveOptions = {
   // Auto-save interval
   useEffect(() => {
     const timer = setInterval(() => {
-      save();
+      saveRef.current();
     }, interval);
 
     return () => clearInterval(timer);
-  }, [save, interval]);
+  }, [interval]);
 
   // beforeunload warning
   useEffect(() => {

--- a/apps/web/src/hooks/useAutoSave.ts
+++ b/apps/web/src/hooks/useAutoSave.ts
@@ -36,18 +36,20 @@ export function useAutoSave({ postId, interval = 30000 }: UseAutoSaveOptions = {
     isDirtyRef.current = false;
   }, []);
 
-  const save = useCallback(() => {
-    if (!isDirtyRef.current) return;
+  const save = useCallback((): boolean => {
+    if (!isDirtyRef.current) return false;
     // save 시점에 실제 변경 여부 확인
     if (JSON.stringify(stateRef.current) === initialStateRef.current) {
       isDirtyRef.current = false;
-      return;
+      return false;
     }
     const { title, content } = stateRef.current;
-    if (!title.trim() && !content.trim()) return;
+    if (!title.trim() && !content.trim()) return false;
 
     saveDraft(stateRef.current, postId);
+    isDirtyRef.current = false;
     setLastSaved(new Date().toISOString());
+    return true;
   }, [postId]);
 
   const saveRef = useRef(save);
@@ -77,6 +79,7 @@ export function useAutoSave({ postId, interval = 30000 }: UseAutoSaveOptions = {
     const handler = (e: BeforeUnloadEvent) => {
       if (isDirtyRef.current) {
         e.preventDefault();
+        e.returnValue = '';
       }
     };
     window.addEventListener('beforeunload', handler);

--- a/apps/web/src/utils/draft.ts
+++ b/apps/web/src/utils/draft.ts
@@ -22,11 +22,26 @@ export function saveDraft(data: Omit<DraftData, 'savedAt'>, postId?: number): vo
   }
 }
 
+function isDraftData(value: unknown): value is DraftData {
+  if (typeof value !== 'object' || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.title === 'string' &&
+    typeof obj.content === 'string' &&
+    typeof obj.excerpt === 'string' &&
+    typeof obj.coverImage === 'string' &&
+    Array.isArray(obj.tagIds) &&
+    typeof obj.savedAt === 'string'
+  );
+}
+
 export function loadDraft(postId?: number): DraftData | null {
   try {
     const raw = localStorage.getItem(getKey(postId));
     if (!raw) return null;
-    return JSON.parse(raw) as DraftData;
+    const parsed: unknown = JSON.parse(raw);
+    if (!isDraftData(parsed)) return null;
+    return parsed;
   } catch {
     return null;
   }

--- a/apps/web/src/utils/draft.ts
+++ b/apps/web/src/utils/draft.ts
@@ -1,0 +1,45 @@
+const DRAFT_PREFIX = 'post_draft_';
+
+export interface DraftData {
+  title: string;
+  content: string;
+  excerpt: string;
+  coverImage: string;
+  tagIds: string[];
+  savedAt: string;
+}
+
+function getKey(postId?: number): string {
+  return `${DRAFT_PREFIX}${postId ?? 'new'}`;
+}
+
+export function saveDraft(data: Omit<DraftData, 'savedAt'>, postId?: number): void {
+  try {
+    const draft: DraftData = { ...data, savedAt: new Date().toISOString() };
+    localStorage.setItem(getKey(postId), JSON.stringify(draft));
+  } catch {
+    // localStorage full or unavailable
+  }
+}
+
+export function loadDraft(postId?: number): DraftData | null {
+  try {
+    const raw = localStorage.getItem(getKey(postId));
+    if (!raw) return null;
+    return JSON.parse(raw) as DraftData;
+  } catch {
+    return null;
+  }
+}
+
+export function deleteDraft(postId?: number): void {
+  try {
+    localStorage.removeItem(getKey(postId));
+  } catch {
+    // ignore
+  }
+}
+
+export function hasDraft(postId?: number): boolean {
+  return !!loadDraft(postId);
+}


### PR DESCRIPTION
## 변경 사항

- localStorage 기반 드래프트 저장/복원/삭제 유틸리티 (utils/draft.ts) 추가
- useAutoSave 훅: 30초 간격 자동 저장 + beforeunload 이탈 경고
- saveRef 패턴으로 interval 불필요한 재시작 방지 최적화
- DraftBanner 컴포넌트: 임시 저장 복원/삭제 UI
- PostEditor에 자동 저장 통합 (상태 표시, 로컬 저장 버튼)
- 서버 저장 성공 시 로컬 드래프트 자동 삭제

## 변경된 파일

- `apps/web/src/components/post/DraftBanner.tsx` (+38)
- `apps/web/src/components/post/PostEditor.tsx` (+84/-12)
- `apps/web/src/hooks/useAutoSave.ts` (+80)
- `apps/web/src/utils/draft.ts` (+45)

## 관련 이슈

- Closes #67

## 테스트

- [ ] 로컬에서 테스트 완료
- [ ] 빌드 성공 확인

## 체크리스트

- [ ] 코드 리뷰 완료
- [ ] 타입 체크 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * 포스트 작성 중 30초 간격 자동 저장 기능 추가
  * 즉시 저장 가능한 "로컬 저장" 버튼 추가 및 저장 시 토스트 표시
  * 이전에 저장된 로컬 드래프트가 있으면 복원/삭제할 수 있는 배너 표시
  * 마지막 자동 저장 시간 UI에 표시
  * 저장되지 않은 변경사항이 있을 때 페이지 이탈 경고 제공
<!-- end of auto-generated comment: release notes by coderabbit.ai -->