### PR TITLE
[Fix] #73 어드민 이미지 드래그앤드롭 순서 변경 및 삭제 버그 수정

### DIFF
--- a/apps/web/src/components/editor/portfolio/SortableItems.tsx
+++ b/apps/web/src/components/editor/portfolio/SortableItems.tsx
@@ -195,10 +195,10 @@ export function SortableImageItem({
         alt={`Project ${index + 1}`}
         className="w-24 h-24 object-cover"
       />
-      <div className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center gap-2">
+      <div className="pointer-events-none absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center gap-2">
         <button
           type="button"
-          className="p-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600 transition-colors cursor-grab active:cursor-grabbing"
+          className="pointer-events-auto p-2 bg-gray-700 text-white rounded-lg hover:bg-gray-600 transition-colors cursor-grab active:cursor-grabbing"
           {...attributes}
           {...listeners}
         >
@@ -206,8 +206,11 @@ export function SortableImageItem({
         </button>
         <button
           type="button"
-          onClick={onRemove}
-          className="p-2 bg-red-500 text-white rounded-lg hover:bg-red-600 transition-colors"
+          onClick={(e) => {
+            e.stopPropagation();
+            onRemove();
+          }}
+          className="pointer-events-auto p-2 bg-red-500 text-white rounded-lg hover:bg-red-600 transition-colors"
         >
           <Trash2 className="h-4 w-4" />
         </button>

--- a/apps/web/src/components/editor/portfolio/sections/ProjectImagesSection.tsx
+++ b/apps/web/src/components/editor/portfolio/sections/ProjectImagesSection.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import type { PortfolioProject } from '@/types/portfolio';
 import { ImageUploadModal } from '@/components/ui';
 import { SortableImageItem } from '../SortableItems';
@@ -17,7 +17,7 @@ import {
   arrayMove,
   SortableContext,
   sortableKeyboardCoordinates,
-  verticalListSortingStrategy,
+  rectSortingStrategy,
 } from '@dnd-kit/sortable';
 import { Plus, Image as ImageIcon } from 'lucide-react';
 
@@ -46,6 +46,15 @@ export function ProjectImagesSection({
     })
   );
 
+  const imageIds = useMemo(() => {
+    const seen = new Map<string, number>();
+    return (project.images || []).map((url) => {
+      const count = seen.get(url) || 0;
+      seen.set(url, count + 1);
+      return count === 0 ? `img-${url}` : `img-${url}-dup${count}`;
+    });
+  }, [project.images]);
+
   const handleAddImage = (url: string) => {
     onChange('images', [...(project.images || []), url]);
   };
@@ -61,9 +70,11 @@ export function ProjectImagesSection({
     const { active, over } = event;
     if (over && active.id !== over.id) {
       const images = project.images || [];
-      const oldIndex = images.findIndex((_, i) => `image-${i}` === active.id);
-      const newIndex = images.findIndex((_, i) => `image-${i}` === over.id);
-      onChange('images', arrayMove(images, oldIndex, newIndex));
+      const oldIndex = imageIds.indexOf(active.id as string);
+      const newIndex = imageIds.indexOf(over.id as string);
+      if (oldIndex !== -1 && newIndex !== -1) {
+        onChange('images', arrayMove(images, oldIndex, newIndex));
+      }
     }
   };
 
@@ -97,14 +108,14 @@ export function ProjectImagesSection({
           onDragEnd={handleImageDragEnd}
         >
           <SortableContext
-            items={(project.images || []).map((_, i) => `image-${i}`)}
-            strategy={verticalListSortingStrategy}
+            items={imageIds}
+            strategy={rectSortingStrategy}
           >
             <div className="flex flex-wrap gap-3">
               {project.images.map((url, index) => (
                 <SortableImageItem
-                  key={`image-${index}`}
-                  id={`image-${index}`}
+                  key={imageIds[index]}
+                  id={imageIds[index]}
                   url={url}
                   index={index}
                   onRemove={() => handleRemoveImage(index)}

--- a/apps/web/src/components/editor/portfolio/sections/ProjectImagesSection.tsx
+++ b/apps/web/src/components/editor/portfolio/sections/ProjectImagesSection.tsx
@@ -4,6 +4,7 @@ import { useState, useMemo } from 'react';
 import type { PortfolioProject } from '@/types/portfolio';
 import { ImageUploadModal } from '@/components/ui';
 import { SortableImageItem } from '../SortableItems';
+import { generateImageIds } from '../../utils';
 import {
   DndContext,
   closestCenter,
@@ -46,14 +47,10 @@ export function ProjectImagesSection({
     })
   );
 
-  const imageIds = useMemo(() => {
-    const seen = new Map<string, number>();
-    return (project.images || []).map((url) => {
-      const count = seen.get(url) || 0;
-      seen.set(url, count + 1);
-      return count === 0 ? `img-${url}` : `img-${url}-dup${count}`;
-    });
-  }, [project.images]);
+  const imageIds = useMemo(
+    () => generateImageIds(project.images),
+    [project.images]
+  );
 
   const handleAddImage = (url: string) => {
     onChange('images', [...(project.images || []), url]);

--- a/apps/web/src/components/editor/resume/ExperienceEditor.tsx
+++ b/apps/web/src/components/editor/resume/ExperienceEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import type { Experience, Project, ProjectTask } from '@/types/resume';
 import { FormField, inputClassName, AutoTextarea } from '../FormField';
 import { StringArrayField } from '../ArrayField';
@@ -20,7 +20,7 @@ import {
   SortableContext,
   sortableKeyboardCoordinates,
   useSortable,
-  verticalListSortingStrategy,
+  rectSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import {
@@ -478,7 +478,11 @@ function ProjectCard({ project, onChange, onRemove }: ProjectCardProps) {
 
   // DnD sensors for images
   const sensors = useSensors(
-    useSensor(PointerSensor),
+    useSensor(PointerSensor, {
+      activationConstraint: {
+        distance: 8,
+      },
+    }),
     useSensor(KeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates,
     }),
@@ -488,13 +492,22 @@ function ProjectCard({ project, onChange, onRemove }: ProjectCardProps) {
     onChange({ ...project, [key]: value });
   };
 
+  const imageIds = useMemo(() => {
+    const seen = new Map<string, number>();
+    return (project.images || []).map((url) => {
+      const count = seen.get(url) || 0;
+      seen.set(url, count + 1);
+      return count === 0 ? `img-${url}` : `img-${url}-dup${count}`;
+    });
+  }, [project.images]);
+
   // Image DnD handler
   const handleImageDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
     if (over && active.id !== over.id) {
       const images = project.images || [];
-      const oldIndex = images.findIndex((_, i) => `image-${i}` === active.id);
-      const newIndex = images.findIndex((_, i) => `image-${i}` === over.id);
+      const oldIndex = imageIds.indexOf(active.id as string);
+      const newIndex = imageIds.indexOf(over.id as string);
       if (oldIndex !== -1 && newIndex !== -1) {
         handleChange('images', arrayMove(images, oldIndex, newIndex));
       }
@@ -682,14 +695,14 @@ function ProjectCard({ project, onChange, onRemove }: ProjectCardProps) {
                 onDragEnd={handleImageDragEnd}
               >
                 <SortableContext
-                  items={(project.images || []).map((_, i) => `image-${i}`)}
-                  strategy={verticalListSortingStrategy}
+                  items={imageIds}
+                  strategy={rectSortingStrategy}
                 >
                   <div className="flex flex-wrap gap-3">
                     {project.images.map((url, index) => (
                       <SortableImageItem
-                        key={`image-${index}`}
-                        id={`image-${index}`}
+                        key={imageIds[index]}
+                        id={imageIds[index]}
                         url={url}
                         index={index}
                         onRemove={() => handleRemoveImage(index)}

--- a/apps/web/src/components/editor/resume/ExperienceEditor.tsx
+++ b/apps/web/src/components/editor/resume/ExperienceEditor.tsx
@@ -5,6 +5,7 @@ import type { Experience, Project, ProjectTask } from '@/types/resume';
 import { FormField, inputClassName, AutoTextarea } from '../FormField';
 import { StringArrayField } from '../ArrayField';
 import { SortableList } from '../SortableList';
+import { generateImageIds } from '../utils';
 import { ImageUploadModal } from '@/components/ui';
 import {
   DndContext,
@@ -492,14 +493,10 @@ function ProjectCard({ project, onChange, onRemove }: ProjectCardProps) {
     onChange({ ...project, [key]: value });
   };
 
-  const imageIds = useMemo(() => {
-    const seen = new Map<string, number>();
-    return (project.images || []).map((url) => {
-      const count = seen.get(url) || 0;
-      seen.set(url, count + 1);
-      return count === 0 ? `img-${url}` : `img-${url}-dup${count}`;
-    });
-  }, [project.images]);
+  const imageIds = useMemo(
+    () => generateImageIds(project.images),
+    [project.images]
+  );
 
   // Image DnD handler
   const handleImageDragEnd = (event: DragEndEvent) => {

--- a/apps/web/src/components/editor/utils.ts
+++ b/apps/web/src/components/editor/utils.ts
@@ -1,0 +1,14 @@
+/**
+ * 이미지 URL 배열에서 @dnd-kit용 안정적인 고유 ID 배열을 생성합니다.
+ * - URL을 인코딩하여 안전한 ID 생성
+ * - 중복 URL이 있을 경우 suffix로 구분
+ */
+export function generateImageIds(images: string[] | undefined): string[] {
+  const seen = new Map<string, number>();
+  return (images || []).map((url) => {
+    const count = seen.get(url) || 0;
+    seen.set(url, count + 1);
+    const safeUrl = encodeURIComponent(url);
+    return count === 0 ? `img-${safeUrl}` : `img-${safeUrl}-dup${count}`;
+  });
+}


### PR DESCRIPTION
## 변경 사항

- 인덱스 기반 ID를 URL 기반 안정적 ID로 교체하여 @dnd-kit 아이템 추적 정상화
- `verticalListSortingStrategy`를 `rectSortingStrategy`로 변경하여 그리드 레이아웃 대응
- 포트폴리오 이미지 오버레이에 `pointer-events` 처리 추가하여 삭제 버튼 클릭 가능하도록 수정
- 이력서 `PointerSensor`에 `activationConstraint` 추가하여 클릭 시 드래그 방지

## 변경된 파일

- `apps/web/src/components/editor/portfolio/SortableItems.tsx` (+8, -5)
- `apps/web/src/components/editor/portfolio/sections/ProjectImagesSection.tsx` (+20, -11)
- `apps/web/src/components/editor/resume/ExperienceEditor.tsx` (+21, -6)

## 관련 이슈

- Closes #73

## 테스트

- [ ] 로컬에서 테스트 완료
- [ ] 빌드 성공 확인

## 체크리스트

- [ ] 코드 리뷰 완료
- [ ] 타입 체크 통과

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 드래그 앤 드롭 시 포인터 이벤트 처리 개선으로 더욱 안정적인 상호작용 제공
  * 항목 제거 시 의도하지 않은 클릭 이벤트 전파 방지

* **성능 개선**
  * 포트폴리오 및 경력사항 편집 시 이미지 정렬 기능 최적화
  * 드래그 감지 정확도 향상 및 반응성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->